### PR TITLE
0.2.0

### DIFF
--- a/README.ipynb
+++ b/README.ipynb
@@ -26,16 +26,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pandas in /home/pwwang/miniconda3/lib/python3.7/site-packages (1.2.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.7.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2.8.1)\n",
+      "Requirement already satisfied: numpy>=1.16.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (1.19.4)\n",
+      "Requirement already satisfied: pytz>=2017.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2020.4)\n",
+      "Requirement already satisfied: six>=1.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from python-dateutil>=2.7.3->pandas) (1.15.0)\n",
+      "\u001b[33mWARNING: You are using pip version 19.3.1; however, version 21.0.1 is available.\n",
+      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install pandas"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -96,7 +110,7 @@
        "3  3  three"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -125,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -174,7 +188,7 @@
        "1  1   one"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -189,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -255,7 +269,7 @@
        "3  3  three  1"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -339,7 +353,7 @@
        "3  3  three  3"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -350,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -411,7 +425,7 @@
        "3  3  6"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -489,14 +503,14 @@
        "3  30  three"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Compile the args inside the verb\n",
-    "@register_verb(pd.DataFrame, context=Context.UNSET)\n",
+    "@register_verb(pd.DataFrame, context=Context.PENDING)\n",
     "def mutate_existing(data, column, value):\n",
     "    column = evaluate_expr(column, data, Context.SELECT)\n",
     "    value = evaluate_expr(value, data, Context.EVAL)\n",
@@ -511,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -572,14 +586,14 @@
        "3  60  three"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Evaluate the arguments by yourself\n",
-    "@register_verb(pd.DataFrame, context=Context.UNSET)\n",
+    "@register_verb(pd.DataFrame, context=Context.PENDING)\n",
     "def mutate_existing2(data, column, value):\n",
     "    column = evaluate_expr(column, data, Context.SELECT)\n",
     "    value = evaluate_expr(value, df2, Context.EVAL)\n",
@@ -592,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -601,7 +615,7 @@
        "2"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -622,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -631,7 +645,7 @@
        "1.1"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -642,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -651,7 +665,7 @@
        "6"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -675,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -684,7 +698,7 @@
        "6.4"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -702,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -768,7 +782,7 @@
        "3  3  three  20"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -787,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -853,7 +867,7 @@
        "3  3  three  5"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -869,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -942,7 +956,7 @@
        "3  3  three  5"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -968,7 +982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1034,7 +1048,7 @@
        "3  3  three  9"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1060,203 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>x</th>\n",
-       "      <th>y</th>\n",
-       "      <th>z</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>zero</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>one</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>two</td>\n",
-       "      <td>6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>three</td>\n",
-       "      <td>9</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   x      y  z\n",
-       "0  0   zero  0\n",
-       "1  1    one  3\n",
-       "2  2    two  6\n",
-       "3  3  three  9"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from pipda import ContextBase\n",
-    "\n",
-    "class MyContext(ContextBase):\n",
-    "    def getattr(self, parent, ref):\n",
-    "        # double it to distinguish getattr\n",
-    "        return getattr(parent, ref)\n",
-    "    def getitem(self, parent, ref):\n",
-    "        return parent[ref] * 2\n",
-    "    @property\n",
-    "    def ref(self):\n",
-    "        # how we evaluate the ref in f[ref]\n",
-    "        return self \n",
-    "    \n",
-    "@register_verb(context=MyContext())\n",
-    "def mutate_mycontext(data, **kwargs):\n",
-    "    for key, val in kwargs.items():\n",
-    "        data[key] = val\n",
-    "    return data\n",
-    "\n",
-    "df >> mutate_mycontext(z=f.x + f['x'])\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>x</th>\n",
-       "      <th>y</th>\n",
-       "      <th>z</th>\n",
-       "      <th>zero</th>\n",
-       "      <th>one</th>\n",
-       "      <th>two</th>\n",
-       "      <th>three</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>zero</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>one</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>two</td>\n",
-       "      <td>6</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>three</td>\n",
-       "      <td>9</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   x      y  z  zero  one  two  three\n",
-       "0  0   zero  0     0    1    2      3\n",
-       "1  1    one  3     0    1    2      3\n",
-       "2  2    two  6     0    1    2      3\n",
-       "3  3  three  9     0    1    2      3"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# when ref in f[ref] is also needed to be evaluated\n",
-    "df = df >> mutate(zero=0, one=1, two=2, three=3)\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -1347,7 +1165,230 @@
        "3  3  three  9     0    1    2      3  24"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pipda import ContextBase\n",
+    "\n",
+    "class MyContext(ContextBase):\n",
+    "    name = 'my'\n",
+    "    def getattr(self, parent, ref):\n",
+    "        # double it to distinguish getattr\n",
+    "        return getattr(parent, ref)\n",
+    "    def getitem(self, parent, ref):\n",
+    "        return parent[ref] * 2\n",
+    "    @property\n",
+    "    def ref(self):\n",
+    "        # how we evaluate the ref in f[ref]\n",
+    "        return self \n",
+    "    \n",
+    "    \n",
+    "@register_verb(context=MyContext())\n",
+    "def mutate_mycontext(data, **kwargs):\n",
+    "    for key, val in kwargs.items():\n",
+    "        data[key] = val\n",
+    "    return data\n",
+    "\n",
+    "df >> mutate_mycontext(z=f.x + f['x'])\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>zero</th>\n",
+       "      <th>one</th>\n",
+       "      <th>two</th>\n",
+       "      <th>three</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>zero</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>one</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>two</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>three</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   x      y  z  zero  one  two  three\n",
+       "0  0   zero  0     0    1    2      3\n",
+       "1  1    one  3     0    1    2      3\n",
+       "2  2    two  6     0    1    2      3\n",
+       "3  3  three  9     0    1    2      3"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# when ref in f[ref] is also needed to be evaluated\n",
+    "df = df >> mutate(zero=0, one=1, two=2, three=3)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>x</th>\n",
+       "      <th>y</th>\n",
+       "      <th>z</th>\n",
+       "      <th>zero</th>\n",
+       "      <th>one</th>\n",
+       "      <th>two</th>\n",
+       "      <th>three</th>\n",
+       "      <th>m</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>zero</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>one</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>two</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>three</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>24</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   x      y  z  zero  one  two  three   m\n",
+       "0  0   zero  0     0    1    2      3   0\n",
+       "1  1    one  3     0    1    2      3   8\n",
+       "2  2    two  6     0    1    2      3  16\n",
+       "3  3  three  9     0    1    2      3  24"
+      ]
+     },
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/README.ipynb
+++ b/README.ipynb
@@ -28,23 +28,12 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: pandas in /home/pwwang/miniconda3/lib/python3.7/site-packages (1.2.2)\n",
-      "Requirement already satisfied: pytz>=2017.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2020.4)\n",
-      "Requirement already satisfied: numpy>=1.16.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (1.19.4)\n",
-      "Requirement already satisfied: python-dateutil>=2.7.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2.8.1)\n",
-      "Requirement already satisfied: six>=1.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from python-dateutil>=2.7.3->pandas) (1.15.0)\n",
-      "\u001b[33mWARNING: You are using pip version 19.3.1; however, version 21.0.1 is available.\n",
-      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!pip install pandas"
+    "try:\n",
+    "    import pandas\n",
+    "except ImportError:\n",
+    "    !pip install pandas"
    ]
   },
   {
@@ -194,7 +183,7 @@
     }
    ],
    "source": [
-    "@register_verb(pd.DataFrame)\n",
+    "@register_verb(pd.DataFrame, context=Context.EVAL)\n",
     "def head(data, n=5):\n",
     "    return data.head(n)\n",
     "\n",
@@ -622,12 +611,12 @@
    ],
    "source": [
     "# register for multiple types\n",
-    "@register_verb(int)\n",
+    "@register_verb(int, context=Context.EVAL)\n",
     "def add(data, other):\n",
     "    return data + other\n",
     "\n",
     "# add is actually a singledispatch generic function\n",
-    "@add.register(float)\n",
+    "@add.register(float, context=Context.EVAL)\n",
     "def _(data, other):\n",
     "    return data * other\n",
     "\n",
@@ -673,13 +662,13 @@
    "source": [
     "# As it's a singledispatch generic function, we can do it for multiple types\n",
     "# with the same logic\n",
-    "@register_verb\n",
+    "@register_verb(context=Context.EVAL)\n",
     "def mul(data, other):\n",
     "    raise NotImplementedError # not invalid until types registered\n",
     "\n",
-    "@mul.register(int)\n",
-    "@mul.register(float) \n",
-    "# or you could do @mul.register((int, float))\n",
+    "@mul.register(int, context=Context.EVAL)\n",
+    "@mul.register(float, context=Context.EVAL) \n",
+    "# or you could do @mul.register((int, float), context=Context.EVAL)\n",
     "# context is also supported\n",
     "def _(data, other):\n",
     "    return data * other\n",

--- a/README.ipynb
+++ b/README.ipynb
@@ -34,9 +34,9 @@
      "output_type": "stream",
      "text": [
       "Requirement already satisfied: pandas in /home/pwwang/miniconda3/lib/python3.7/site-packages (1.2.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.7.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2.8.1)\n",
-      "Requirement already satisfied: numpy>=1.16.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (1.19.4)\n",
       "Requirement already satisfied: pytz>=2017.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2020.4)\n",
+      "Requirement already satisfied: numpy>=1.16.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (1.19.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.7.3 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from pandas) (2.8.1)\n",
       "Requirement already satisfied: six>=1.5 in /home/pwwang/miniconda3/lib/python3.7/site-packages (from python-dateutil>=2.7.3->pandas) (1.15.0)\n",
       "\u001b[33mWARNING: You are using pip version 19.3.1; however, version 21.0.1 is available.\n",
       "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -503,7 +503,7 @@
        "3  30  three"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -525,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -586,7 +586,7 @@
        "3  60  three"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -606,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -615,7 +615,7 @@
        "2"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,7 +636,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +645,7 @@
        "1.1"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -665,7 +665,7 @@
        "6"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -689,7 +689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -698,7 +698,7 @@
        "6.4"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -782,7 +782,7 @@
        "3  3  three  20"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -801,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -867,7 +867,7 @@
        "3  3  three  5"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -883,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -956,7 +956,7 @@
        "3  3  three  5"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -982,7 +982,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1048,7 +1048,7 @@
        "3  3  three  9"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1074,7 +1074,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1101,11 +1101,6 @@
        "      <th>x</th>\n",
        "      <th>y</th>\n",
        "      <th>z</th>\n",
-       "      <th>zero</th>\n",
-       "      <th>one</th>\n",
-       "      <th>two</th>\n",
-       "      <th>three</th>\n",
-       "      <th>m</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1114,58 +1109,38 @@
        "      <td>0</td>\n",
        "      <td>zero</td>\n",
        "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1</td>\n",
        "      <td>one</td>\n",
        "      <td>3</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>8</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2</td>\n",
        "      <td>two</td>\n",
        "      <td>6</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>3</td>\n",
        "      <td>three</td>\n",
        "      <td>9</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>24</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   x      y  z  zero  one  two  three   m\n",
-       "0  0   zero  0     0    1    2      3   0\n",
-       "1  1    one  3     0    1    2      3   8\n",
-       "2  2    two  6     0    1    2      3  16\n",
-       "3  3  three  9     0    1    2      3  24"
+       "   x      y  z\n",
+       "0  0   zero  0\n",
+       "1  1    one  3\n",
+       "2  2    two  6\n",
+       "3  3  three  9"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1198,7 +1173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1284,7 +1259,7 @@
        "3  3  three  9     0    1    2      3"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1297,7 +1272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1388,7 +1363,7 @@
        "3  3  three  9     0    1    2      3  24"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ df >> mutate(z=2*f.x) >> select(f.x, f.z)
 # 3    3    6
 
 # Compile the args inside the verb
-@register_verb(pd.DataFrame, context=Context.UNSET)
+@register_verb(pd.DataFrame, context=Context.PENDING)
 def mutate_existing(data, column, value):
     column = evaluate_expr(column, data, Context.SELECT)
     value = evaluate_expr(value, data, Context.EVAL)
@@ -111,7 +111,7 @@ df2
 # 3    30   three 6
 
 # Evaluate the arguments by yourself
-@register_verb(pd.DataFrame, context=Context.UNSET)
+@register_verb(pd.DataFrame, context=Context.PENDING)
 def mutate_existing2(data, column, value):
     column = evaluate_expr(column, data, Context.SELECT)
     value = evaluate_expr(value, df2, Context.EVAL)
@@ -236,6 +236,7 @@ The context defines how a reference (`f.A`, `f['A']`, `f.A.B` is evaluated)
 from pipda import ContextBase
 
 class MyContext(ContextBase):
+    name = 'my'
     def getattr(self, parent, ref):
         # double it to distinguish getattr
         return getattr(parent, ref)
@@ -245,6 +246,7 @@ class MyContext(ContextBase):
     def ref(self):
         # how we evaluate the ref in f[ref]
         return self
+
 
 @register_verb(context=MyContext())
 def mutate_mycontext(data, **kwargs):

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ def _(data, other):
 
 # As it's a singledispatch generic function, we can do it for multiple types
 # with the same logic
-@register_verb
+@register_verb(context=Context.EVAL)
 def mul(data, other):
     raise NotImplementedError # not invalid until types registered
 

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -5,7 +5,7 @@ from .verb import register_verb, register_piping_sign
 from .function import register_func
 from .utils import (
     evaluate_args, evaluate_kwargs, evaluate_expr,
-    DataContext, functype, unregister
+    DataEnv, functype, unregister
 )
 from .context import Context, ContextBase
 from .operator import Operator, register_operator

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -5,7 +5,7 @@ from .verb import register_verb, register_piping_sign
 from .function import register_func
 from .utils import (
     evaluate_args, evaluate_kwargs, evaluate_expr,
-    DataEnv, functype, unregister
+    DataEnv, functype, unregister, logger
 )
 from .context import Context, ContextBase
 from .operator import Operator, register_operator

--- a/pipda/context.py
+++ b/pipda/context.py
@@ -11,7 +11,7 @@ By default,
 
 from abc import ABC, abstractmethod, abstractproperty
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Union
 
 class ContextError(Exception):
     """Any errors related to contexts"""
@@ -153,3 +153,5 @@ class Context(Enum):
     SELECT = ContextSelect()
     EVAL = ContextEval()
     MIXED = ContextMixed()
+
+ContextAnnoType = Union[Context, ContextBase]

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -88,7 +88,7 @@ class Function(Expression):
             kwargs['_context'] = None
 
         bondargs = signature.bind(*args, **kwargs)
-        # bondargs.apply_defaults()
+        bondargs.apply_defaults()
         if func_extra_contexts:
             # evaluate some specfic args
             for key, ctx in func_extra_contexts.items():
@@ -131,18 +131,16 @@ def _register_function_no_datarg(
 
         if verb_arg_only and _env is None:
             raise ValueError(
-                f"Function {func.__qualname__!r} can only be called as "
-                "an argument of a verb."
+                f"`{func.__qualname__}` must only be used inside verbs"
             )
 
         # Otherwise I am standalone
         if have_expr(args, kwargs):
             if _env is None:
                 raise ValueError(
-                    "Function without data argument can't be called with "
-                    "Expression objects as arguments, unless it's called "
-                    "inside with statement of DataEnv or data is passed "
-                    "to _env."
+                    f"`{func.__qualname__}` has to be used in piping "
+                    "environment, inside with statement of DataEnv or "
+                    "data is passed to _env."
                 )
 
         if _env is None:
@@ -189,8 +187,7 @@ def _register_function_datarg(
 
         if verb_arg_only and _env is None:
             raise ValueError(
-                f"Function {func.__qualname__!r} can only be called as "
-                "an argument of a verb."
+                f"`{func.__qualname__}` must only be used inside verbs"
             )
 
         if have_expr(args[1:], kwargs):

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -107,7 +107,7 @@ def _register_function_no_datarg(
             **kwargs: Any
     ) -> Any:
 
-        _env = _env or calling_env()
+        _env = _env or calling_env(register_func.astnode_fail_warning)
 
         # As argument of a verb
         if isinstance(_env, str) and _env == 'piping':
@@ -166,7 +166,7 @@ def _register_function_datarg(
             _env: Optional[str] = None,
             **kwargs: Any
     ) -> Any:
-        _env = _env or calling_env()
+        _env = _env or calling_env(register_func.astnode_fail_warning)
         # As argument of a verb
         if isinstance(_env, str) and _env == 'piping':
             return Function(generic, context, args, kwargs)
@@ -228,3 +228,4 @@ def register_func(
     return _register_function_datarg(cls, context, func)
 
 register_func.default_context = Context.EVAL
+register_func.astnode_fail_warning = True

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -6,9 +6,9 @@ from typing import (
     Any, Callable, Iterable, Mapping, Optional, Tuple, Type, Union
 )
 from .utils import (
-    Expression, NULL,
+    Expression,
     evaluate_args, evaluate_expr, evaluate_kwargs, calling_env, have_expr,
-    singledispatch_register
+    singledispatch_register, logger
 )
 from .context import (
     Context, ContextAnnoType, ContextBase, ContextError
@@ -80,6 +80,8 @@ class Function(Expression):
 
         bondargs = signature.bind(*args, **kwargs)
         bondargs.apply_defaults()
+
+        logger.debug('Evaluating %r with context %r.', self, context)
         if func_extra_contexts:
             # evaluate some specfic args
             for key, ctx in func_extra_contexts.items():

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -1,4 +1,5 @@
 """Provides register_func to register functions"""
+from enum import Enum
 import inspect
 from functools import singledispatch, wraps
 from types import FunctionType
@@ -11,7 +12,7 @@ from .utils import (
     singledispatch_register, logger
 )
 from .context import (
-    Context, ContextAnnoType, ContextBase, ContextError
+    ContextAnnoType, ContextBase, ContextError
 )
 
 class Function(Expression):
@@ -231,14 +232,14 @@ def register_func(
             extra_contexts
         )
 
-    if isinstance(context, Context):
+    if isinstance(context, Enum):
         context = context.value
 
     func.context = context
 
     extra_contexts = extra_contexts or {}
     func.extra_contexts = {
-        key: ctx.value if isinstance(ctx, Context) else ctx
+        key: ctx.value if isinstance(ctx, Enum) else ctx
         for key, ctx in extra_contexts.items()
     }
 

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -6,10 +6,11 @@ from typing import (
 )
 from .utils import (
     Expression, NULL,
-    evaluate_args, evaluate_kwargs, calling_type, singledispatch_register
+    evaluate_args, evaluate_kwargs, calling_type, have_expr,
+    singledispatch_register
 )
 from .context import (
-    Context, ContextBase, ContextError, ContextEval, ContextMixed
+    Context, ContextBase, ContextError
 )
 
 class Function(Expression):
@@ -102,7 +103,11 @@ def _register_function_no_datarg(
 
         _calling_type = _calling_type or calling_type()
         # Use is since _calling_type could be a dataframe or series
-        if isinstance(_calling_type, str) and _calling_type == 'piping':
+        if (
+                (isinstance(_calling_type, str) and
+                 _calling_type == 'piping') or
+                have_expr(args, kwargs)
+        ):
             return Function(func, context, args, kwargs, False)
 
         if _calling_type is None:
@@ -147,7 +152,11 @@ def _register_function_datarg(
                 _calling_type: Optional[str] = None,
                 **kwargs: Any) -> Any:
         _calling_type = _calling_type or calling_type()
-        if isinstance(_calling_type, str) and _calling_type == 'piping':
+        if (
+                (isinstance(_calling_type, str) and
+                 _calling_type == 'piping') or
+                have_expr(args, kwargs)
+        ):
             return Function(generic, context, args, kwargs)
 
         if _calling_type is None:

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -86,7 +86,7 @@ class Function(Expression):
         if self.__class__.__name__ == 'Verb':
             level = 0
 
-        prefix = '- ' if level == 0 else f'  ' * level
+        prefix = '- ' if level == 0 else '  ' * level
         logger.debug('%sEvaluating %r with context %r.', prefix, self, context)
         if func_extra_contexts:
             # evaluate some specfic args

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -112,8 +112,9 @@ def _register_function_no_datarg(
             if _env is None:
                 raise ValueError(
                     "Function without data argument can't be called with "
-                    "Expression objects as arguments, unless it's called inside "
-                    "with statement of DataContext or data is passed to _env."
+                    "Expression objects as arguments, unless it's called "
+                    "inside with statement of DataContext or data is passed "
+                    "to _env."
                 )
 
         if _env is None:

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -119,7 +119,7 @@ def _register_function_no_datarg(
                 raise ValueError(
                     "Function without data argument can't be called with "
                     "Expression objects as arguments, unless it's called "
-                    "inside with statement of DataContext or data is passed "
+                    "inside with statement of DataEnv or data is passed "
                     "to _env."
                 )
 

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -1,4 +1,5 @@
 """Provides register_func to register functions"""
+import inspect
 from functools import singledispatch, wraps
 from types import FunctionType
 from typing import (
@@ -63,8 +64,10 @@ class Function(Expression):
         """
         dispatch = getattr(self.func, 'dispatch', None)
         func_context = NULL
+        dispatcher = self.func
         if dispatch is not None:
-            func_context = getattr(dispatch(type(data)), 'context', NULL)
+            dispatcher = dispatch(type(data))
+            func_context = getattr(dispatcher, 'context', NULL)
 
         if func_context is NULL:
             # No context specified for a second type
@@ -79,6 +82,9 @@ class Function(Expression):
             raise ContextError(
                 f'Cannot evaluate {self!r} with an unset context.'
             )
+
+        if '_context' in inspect.signature(dispatcher).parameters:
+            self.kwargs['_context'] = context
 
         if context.name == 'pending':
             # leave args/kwargs for the child

--- a/pipda/operator.py
+++ b/pipda/operator.py
@@ -78,7 +78,8 @@ class Operator(Function):
     def __call__(
             self,
             data: Any,
-            context: Optional[ContextBase] = None
+            context: Optional[ContextBase] = None,
+            level: int = 0
     ) -> Any:
         """Evaluate the operator
 
@@ -88,7 +89,7 @@ class Operator(Function):
         # set the context and data in case they need to be used
         # inside the function.
         self.data = data
-        return super().__call__(data, context)
+        return super().__call__(data, context, level)
 
     def __getattr__(self, name: str) -> Any:
         """Get the function to handle the operator"""

--- a/pipda/operator.py
+++ b/pipda/operator.py
@@ -1,10 +1,10 @@
 """Provide the Operator class"""
 from functools import wraps
 import operator
-from typing import Any, Mapping, Optional, Tuple, Type
+from typing import Any, Callable, Mapping, Optional, Tuple, Type
 
 from .function import Function
-from .context import ContextBase
+from .context import Context, ContextAnnoType, ContextBase
 
 class Operator(Function):
     """Operator class, defining how the operators in verb/function arguments
@@ -26,15 +26,10 @@ class Operator(Function):
 
     def __init__(self,
                  op: str,
-                 context: Optional[ContextBase],
                  args: Tuple[Any],
                  kwargs: Mapping[str, Any],
                  datarg: bool = False) -> None:
 
-        assert context is None, (
-            "No context should be passed "
-            f"when initialize a {self.__class__.__name__} object."
-        )
         self.op = op
         self.data = None
         # if the function is defined directly, use it.
@@ -54,13 +49,33 @@ class Operator(Function):
             def left_op_func(arg_a, arg_b, *args, **kwargs):
                 return op_func(arg_b, arg_a, *args, **kwargs)
 
-            super().__init__(left_op_func, context, args, kwargs, datarg)
+            super().__init__(left_op_func, args, kwargs, datarg)
         elif op_func:
-            super().__init__(op_func, context, args, kwargs, datarg)
+            super().__init__(op_func, args, kwargs, datarg)
         else:
             raise ValueError(f'No operator function defined for {self.op!r}')
 
-    def evaluate(
+    @staticmethod
+    def set_context(
+            context: ContextAnnoType,
+            extra_contexts: Optional[Mapping[str, ContextAnnoType]] = None
+    ) -> Callable[[Callable], Callable]:
+        """Set custom context for a operator method"""
+
+        def wrapper(func):
+            func.context = (
+                context.value if isinstance(context, Context) else context
+            )
+            extra_contexts2 = extra_contexts or {}
+            func.extra_contexts = {
+                key: ctx.value if isinstance(ctx, Context) else ctx
+                for key, ctx in extra_contexts2.items()
+            }
+            return func
+
+        return wrapper
+
+    def __call__(
             self,
             data: Any,
             context: Optional[ContextBase] = None
@@ -70,16 +85,10 @@ class Operator(Function):
         No data passed to the operator function. It should be used to evaluate
         the arguments.
         """
-        context = context or self.context
-        assert context is not None, (
-            "A context is needed to evaluate "
-            f"a {self.__class__.__name__} object"
-        )
         # set the context and data in case they need to be used
         # inside the function.
-        self.context = context
         self.data = data
-        return super().evaluate(data, context)
+        return super().__call__(data, context)
 
     def __getattr__(self, name: str) -> Any:
         """Get the function to handle the operator"""

--- a/pipda/operator.py
+++ b/pipda/operator.py
@@ -1,10 +1,11 @@
 """Provide the Operator class"""
+from enum import Enum
 from functools import wraps
 import operator
 from typing import Any, Callable, Mapping, Optional, Tuple, Type
 
 from .function import Function
-from .context import Context, ContextAnnoType, ContextBase
+from .context import ContextAnnoType, ContextBase
 
 class Operator(Function):
     """Operator class, defining how the operators in verb/function arguments
@@ -64,11 +65,11 @@ class Operator(Function):
 
         def wrapper(func):
             func.context = (
-                context.value if isinstance(context, Context) else context
+                context.value if isinstance(context, Enum) else context
             )
             extra_contexts2 = extra_contexts or {}
             func.extra_contexts = {
-                key: ctx.value if isinstance(ctx, Context) else ctx
+                key: ctx.value if isinstance(ctx, Enum) else ctx
                 for key, ctx in extra_contexts2.items()
             }
             return func

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -21,14 +21,8 @@ class Reference(Expression, ABC):
     """
     def __init__(self,
                  parent: Any,
-                 ref: Any,
-                 context: Optional[ContextBase] = None) -> None:
-        super().__init__(context)
+                 ref: Any) -> None:
 
-        assert context is None, (
-            "No context should be passed to initialize "
-            f"a {self.__class__.__name__} object."
-        )
         self.parent = parent
         self.ref = ref
 
@@ -39,7 +33,7 @@ class Reference(Expression, ABC):
         )
 
     @abstractmethod
-    def evaluate(
+    def __call__(
             self,
             data: Any,
             context: Optional[ContextBase] = None
@@ -53,26 +47,26 @@ class Reference(Expression, ABC):
 class ReferenceAttr(Reference):
     """Attribute references, for example: `f.A`, `f.A.B` etc."""
 
-    def evaluate(
+    def __call__(
             self,
             data: Any,
             context: Optional[ContextBase] = None
     ) -> Any:
         """Evaluate the attribute references"""
-        super().evaluate(data, context)
+        super().__call__(data, context)
         parent = evaluate_expr(self.parent, data, context)
         return context.getattr(parent, self.ref)
 
 class ReferenceItem(Reference):
     """Subscript references, for example: `f['A']`, `f.A['B']` etc"""
 
-    def evaluate(
+    def __call__(
             self,
             data: Any,
             context: Optional[ContextBase] = None
     ) -> Any:
         """Evaluate the subscript references"""
-        super().evaluate(data, context)
+        super().__call__(data, context)
         parent = evaluate_expr(self.parent, data, context)
         ref = evaluate_expr(self.ref, data, context.ref)
         return context.getitem(parent, ref)
@@ -101,7 +95,7 @@ class Symbolic(Expression):
     def __repr__(self) -> str:
         return f"<Symbolic:{self.__varname__}>"
 
-    def evaluate(
+    def __call__(
             self,
             data: Any,
             context: Optional[ContextBase] = None

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -40,7 +40,7 @@ class Reference(Expression, ABC):
             level: int = 0
     ) -> Any:
         """Evaluate the reference according to the context"""
-        prefix = '- ' if level == 0 else f'  ' * level
+        prefix = '- ' if level == 0 else '  ' * level
         logger.debug('%sEvaluating %r with context %r.', prefix, self, context)
         assert context is not None, (
             f"Cannot evaluate a {self.__class__.__name__} "

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -1,4 +1,5 @@
 """Provide the utilities and Expression class"""
+from enum import Enum
 import sys
 import ast
 import logging
@@ -12,7 +13,7 @@ from abc import ABC, abstractmethod
 
 from executing import Source
 
-from .context import Context, ContextAnnoType, ContextBase
+from .context import ContextAnnoType, ContextBase
 
 NULL = object()
 DATA_CONTEXTVAR_NAME = '__pipda_data__'
@@ -268,7 +269,7 @@ def evaluate_expr(
         level: int = 0
 ) -> Any:
     """Evaluate a mixed expression"""
-    if isinstance(context, Context):
+    if isinstance(context, Enum):
         context = context.value
 
     if isinstance(expr, list):
@@ -337,7 +338,7 @@ def singledispatch_register(
 
         if func is None:
             return lambda fun: register_func(cls, context, fun)
-        if isinstance(context, Context):
+        if isinstance(context, Enum):
             context = context.value
         func.context = context
         ret = func

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -193,7 +193,7 @@ def is_argument_node_of(sub_node: ast.Call) -> Optional[ast.Call]:
         parent = getattr(parent, 'parent', None)
     return None
 
-def calling_env() -> Any:
+def calling_env(astnode_fail_warning: bool = True) -> Any:
     """Checking how the function is called:
     - piping:
         1. It is a verb that is piped directed. ie. data >> verb(...)
@@ -227,7 +227,7 @@ def calling_env() -> Any:
     # frame 2: func(...)
     frame = sys._getframe(2)
     my_node = Source.executing(frame).node
-    if not my_node:
+    if not my_node and astnode_fail_warning:
         warnings.warn(
             "Failed to fetch the node calling the function, "
             "call it with the original function."
@@ -235,7 +235,7 @@ def calling_env() -> Any:
         return None
 
     piping_verb_node = get_verb_node(my_node)
-    if piping_verb_node is my_node:
+    if piping_verb_node is my_node and piping_verb_node is not None:
         return 'piping-verb'
 
     if is_argument_node(my_node, piping_verb_node):

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -168,6 +168,9 @@ def is_argument_node(
                 is_argument_node_of(parent) is verb_node
         ):
             return True
+        if isinstance(parent, ast.Lambda):
+            # function inside lambda is not in a piping environment
+            return False
         parent = getattr(parent, 'parent', None)
     # when verb_node is ensured, we can anyway retrieve it as the parent of
     # sub_node
@@ -190,7 +193,7 @@ def is_argument_node_of(sub_node: ast.Call) -> Optional[ast.Call]:
         parent = getattr(parent, 'parent', None)
     return None
 
-def calling_type() -> Any:
+def calling_env() -> Any:
     """Checking how the function is called:
     - piping:
         1. It is a verb that is piped directed. ie. data >> verb(...)

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -288,6 +288,10 @@ def evaluate_expr(
         ret = (expr.evaluate(data, context)
                if not expr.context
                else expr.evaluate(data))
+        # in case there is middlewares that return an Expression object
+        # evaluate it as well.
+
+        # return evaluate_expr(ret, data, context)
         return ret
     return expr
 

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -98,7 +98,7 @@ class Expression(ABC):
     ) -> Any:
         """Evaluate the expression using given data"""
 
-class DataContext:
+class DataEnv:
     """A data context that can be accessed by the function registered by
     `pipda.register_*` so that the data argument doesn't need to
     be passed when called
@@ -147,7 +147,7 @@ def get_context_data(frame: FrameType) -> Any:
     """Check and return if there is a data set in the context where
     the verb or function is called"""
     for value in frame.f_locals.values():
-        if not isinstance(value, DataContext):
+        if not isinstance(value, DataEnv):
             continue
         if value.name != DATA_CONTEXTVAR_NAME:
             continue

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -141,12 +141,14 @@ def get_verb_node(
     parent = getattr(child, 'parent', None)
     while parent:
         if (
-                isinstance(parent, ast.BinOp) and
-                isinstance(parent.op,
-                           PIPING_SIGNS[Verb.CURRENT_SIGN].token) and
-                parent.right is child
+                (
+                    isinstance(parent, ast.BinOp) and parent.right is child or
+                    isinstance(parent, ast.AugAssign) and parent.value is child
+                ) and
+                isinstance(parent.op, PIPING_SIGNS[Verb.CURRENT_SIGN].token)
         ):
             return child
+
         child = parent
         parent = getattr(parent, 'parent', None)
     return None

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -1,6 +1,7 @@
 """Provide the utilities and Expression class"""
 import sys
 import ast
+import logging
 from types import FrameType
 import warnings
 from functools import partialmethod
@@ -15,6 +16,17 @@ from .context import Context, ContextAnnoType, ContextBase
 
 NULL = object()
 DATA_CONTEXTVAR_NAME = '__pipda_data__'
+
+
+# logger
+logger = logging.getLogger('pipda') # pylint: disable=invalid-name
+logger.setLevel(logging.INFO)
+stream_handler = logging.StreamHandler() # pylint: disable=invalid-name
+stream_handler.setFormatter(logging.Formatter(
+    '[%(asctime)s][%(name)s][%(levelname)7s] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+))
+logger.addHandler(stream_handler)
 
 class Expression(ABC):
     """The abstract Expression class"""

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 
 from executing import Source
 
-from .context import Context, ContextBase
+from .context import Context, ContextAnnoType, ContextBase
 
 NULL = object()
 DATA_CONTEXTVAR_NAME = '__pipda_data__'
@@ -257,7 +257,7 @@ def calling_env(astnode_fail_warning: bool = True) -> Any:
 def evaluate_expr(
         expr: Any,
         data: Any,
-        context: Union[Context, ContextBase]
+        context: ContextAnnoType
 ) -> Any:
     """Evaluate a mixed expression"""
     if isinstance(context, Context):
@@ -301,7 +301,7 @@ def evaluate_expr(
 def evaluate_args(
         args: Tuple[Any],
         data: Any,
-        context: Union[Context, ContextBase]
+        context: ContextAnnoType
 ) -> Tuple[Any]:
     """Evaluate the non-keyword arguments"""
     return tuple(evaluate_expr(arg, data, context) for arg in args)
@@ -309,7 +309,7 @@ def evaluate_args(
 def evaluate_kwargs(
         kwargs: Mapping[str, Any],
         data: Any,
-        context: Union[Context, ContextBase]
+        context: ContextAnnoType
 ) -> Mapping[str, Any]:
     """Evaluate the keyword arguments"""
     return {

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -380,3 +380,13 @@ def unregister(func: Callable) -> Callable:
     if origfunc is None:
         raise ValueError(f'Function is not registered with pipda: {func}')
     return origfunc
+
+def have_expr(args: Tuple[Any], kwargs: Mapping[str, Any]) -> bool:
+    """Check if arg and kwargs have Expression object"""
+    for arg in args:
+        if isinstance(arg, Expression):
+            return True
+    for arg in kwargs.values():
+        if isinstance(arg, Expression):
+            return True
+    return False

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -5,7 +5,7 @@ from functools import singledispatch, wraps
 from types import FunctionType
 from typing import Any, Callable, ClassVar, Iterable, Optional, Type, Union
 
-from .utils import NULL, calling_type, singledispatch_register
+from .utils import NULL, calling_type, have_expr, singledispatch_register
 from .function import Function
 from .context import ContextBase, Context
 
@@ -98,7 +98,11 @@ def register_verb(
         if isinstance(_calling_type, str) and _calling_type == 'piping-verb':
             return Verb(generic, context, args, kwargs)
 
-        if isinstance(_calling_type, str) and _calling_type == 'piping':
+        if (
+                (isinstance(_calling_type, str) and
+                 _calling_type == 'piping') or
+                have_expr(args, kwargs)
+        ):
             # Use the verb's context
             return Function(generic, None, args, kwargs, False)
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -1,6 +1,7 @@
 """Provide register_verb to register verbs"""
 import ast
 from collections import namedtuple
+from enum import Enum
 from functools import singledispatch, wraps
 from types import FunctionType
 from typing import (
@@ -9,7 +10,7 @@ from typing import (
 
 from .utils import calling_env, have_expr, singledispatch_register
 from .function import Function
-from .context import ContextAnnoType, Context
+from .context import ContextAnnoType
 
 # The Sign tuple
 Sign = namedtuple('Sign', ['method', 'token'])
@@ -69,7 +70,7 @@ def register_verb(
     if not isinstance(cls, (tuple, set, list)):
         cls = (cls, )
 
-    if isinstance(context, Context):
+    if isinstance(context, Enum):
         context = context.value
 
     # allow register to have different context
@@ -77,7 +78,7 @@ def register_verb(
 
     extra_contexts = extra_contexts or {}
     func.extra_contexts = {
-        key: ctx.value if isinstance(ctx, Context) else ctx
+        key: ctx.value if isinstance(ctx, Enum) else ctx
         for key, ctx in extra_contexts.items()
     }
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -101,7 +101,10 @@ def register_verb(
             _env: Optional[str] = None,
             **kwargs: Any
     ) -> Any:
-        _env = _env or calling_env(register_verb.astnode_fail_warning)
+        _env = (
+            calling_env(register_verb.astnode_fail_warning)
+            if _env is None else _env
+        )
         if isinstance(_env, str) and _env == 'piping-verb':
             return Verb(generic, args, kwargs)
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -113,7 +113,7 @@ def register_verb(
         # If I have Expression objects as arguments, treat it as a Verb
         # and execute it, with the first argument as data
         if have_expr(args[1:], kwargs):
-            return Function(generic, args[1:], kwargs )(args[0])
+            return Function(generic, args[1:], kwargs)(args[0])
 
         if _env is None:
             return generic(*args, **kwargs)

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, ClassVar, Iterable, Optional, Type, Union
 
 from .utils import NULL, calling_env, have_expr, singledispatch_register
 from .function import Function
-from .context import ContextBase, Context
+from .context import ContextAnnoType, ContextBase, Context
 
 # The Sign tuple
 Sign = namedtuple('Sign', ['method', 'token'])
@@ -53,7 +53,7 @@ register_piping_sign('>>')
 
 def register_verb(
         cls: Union[FunctionType, Type, Iterable[Type]] = object,
-        context: Union[Context, ContextBase] = NULL,
+        context: ContextAnnoType = NULL,
         func: Optional[FunctionType] = None
 ) -> Callable:
     """Mimic the singledispatch function to implement a function for

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -94,7 +94,7 @@ def register_verb(
             _env: Optional[str] = None,
             **kwargs: Any
     ) -> Any:
-        _env = _env or calling_env()
+        _env = _env or calling_env(register_verb.astnode_fail_warning)
         if isinstance(_env, str) and _env == 'piping-verb':
             return Verb(generic, context, args, kwargs)
 
@@ -129,3 +129,4 @@ def register_verb(
     return wrapper
 
 register_verb.default_context = Context.SELECT
+register_verb.astnode_fail_warning = True

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -128,5 +128,5 @@ def register_verb(
 
     return wrapper
 
-register_verb.default_context = Context.SELECT
+register_verb.default_context = Context.EVAL
 register_verb.astnode_fail_warning = True

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -16,7 +16,7 @@ def test_use_unset():
         ...
 
     with pytest.raises(ContextError):
-        add(1, _calling_type='piping').evaluate(1, context=None)
+        add(1, _env='piping').evaluate(1, context=None)
 
 def test_context_passby():
     f = Symbolic()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,51 @@
+import pytest
+
+from pipda import *
+from pipda.context import *
+
+def test_use_pending():
+    f = Symbolic()
+    with pytest.raises(NotImplementedError):
+        f.a.evaluate(None, context=Context.PENDING.value)
+    with pytest.raises(NotImplementedError):
+        f['a'].evaluate(None, context=Context.PENDING.value)
+
+def test_use_unset():
+    @register_func(context=None)
+    def add(data, x):
+        ...
+
+    with pytest.raises(ContextError):
+        add(1, _calling_type='piping').evaluate(1, context=None)
+
+def test_context_passby():
+    f = Symbolic()
+
+    @register_verb(context=Context.SELECT)
+    def select(data, *columns):
+        return columns
+
+    @register_verb(context=Context.EVAL)
+    def seldata(data, *columns):
+        return columns
+
+    @register_func(context=Context.UNSET)
+    def get(data, col):
+        return col
+
+    y = {'a':1, 'b':2, 'c':3} >> select(f['a'], get(f['b']))
+    assert y == ('a', 'b')
+
+    y = {'a':1, 'b':2, 'c':3} >> seldata(f['a'], get(f['b']))
+    assert y == (1, 2)
+
+def test_mixed():
+    f = Symbolic()
+
+    @register_verb(context=Context.MIXED)
+    def verb(data, *args, **kwargs):
+        return args, kwargs
+
+    out_args, out_kwargs = [0,1,2] >> verb(f[1], f[3], x=f[1], y=f[2])
+    assert out_args == (1, 3)
+    assert out_kwargs == {'x': 1, 'y': 2}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -148,5 +148,7 @@ def test_debug(caplog):
     logs = caplog.text.splitlines()
     assert "Evaluating Verb(func='test_debug.<locals>.verb') with context <ContextEval" in logs[0]
     assert "Evaluating Function(func='test_debug.<locals>.func1') with context <ContextEval" in logs[1]
-    assert "Evaluating Function(func='test_debug.<locals>.func2') with context <ContextSelect" in logs[2]
-    assert "Evaluating Function(func='test_debug.<locals>.func1') with context <ContextSelect" in logs[3]
+    assert "Evaluating ReferenceItem(parent=<Symbolic:f>, ref=2) with context <ContextEval" in logs[2]
+    assert "Evaluating Function(func='test_debug.<locals>.func2') with context <ContextSelect" in logs[3]
+    assert "Evaluating Function(func='test_debug.<locals>.func1') with context <ContextSelect" in logs[4]
+    assert "Evaluating ReferenceItem(parent=<Symbolic:f>, ref=4) with context <ContextSelect" in logs[5]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,9 +6,9 @@ from pipda.context import *
 def test_use_pending():
     f = Symbolic()
     with pytest.raises(NotImplementedError):
-        f.a.evaluate(None, context=Context.PENDING.value)
+        f.a(None, context=Context.PENDING.value)
     with pytest.raises(NotImplementedError):
-        f['a'].evaluate(None, context=Context.PENDING.value)
+        f['a'](None, context=Context.PENDING.value)
 
 def test_use_unset():
     @register_func(context=None)
@@ -16,7 +16,7 @@ def test_use_unset():
         ...
 
     with pytest.raises(ContextError):
-        add(1, _env='piping').evaluate(1, context=None)
+        add(1, _env='piping')(1, context=None)
 
 def test_context_passby():
     f = Symbolic()
@@ -66,7 +66,7 @@ def test_verb_context_as_argument():
     assert context.name == 'select'
 
     # verb as arg
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def passby(data, x):
         return x
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -183,6 +183,21 @@ def test_unregister():
     with pytest.raises(ValueError):
         unregister(orig)
 
+def test_args_kwargs_have_expr():
+    f = Symbolic()
+    @register_func(None)
+    def func(x):
+        return x
+
+    out = func(f[0], _calling_type=[1])
+    assert out == 1
+
+    out = func(f[0])
+    assert isinstance(out, Expression)
+
+    out = func(x=f[0])
+    assert isinstance(out, Expression)
+
 # def test_return_middleware():
 #     class MiddleWare(Expression):
 #         def evaluate(self, data: Any, context: Optional[ContextBase] = None) -> Any:

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -182,3 +182,25 @@ def test_unregister():
 
     with pytest.raises(ValueError):
         unregister(orig)
+
+# def test_return_middleware():
+#     class MiddleWare(Expression):
+#         def evaluate(self, data: Any, context: Optional[ContextBase] = None) -> Any:
+#             return 'evaluated'
+
+#     @register_func(str)
+#     def midw(x, y=None):
+#         return MiddleWare()
+
+#     @register_verb(str, context=Context.PENDING)
+#     def add(x, y):
+#         return x + evaluate_expr(y, x, context=Context.SELECT)
+
+#     y = "it is " >> add(midw())
+#     assert isinstance(y, str) and y == 'it is evaluated'
+
+#     y = "it is " >> add(midw(midw()))
+#     assert isinstance(y, str) and y == 'it is evaluated'
+
+#     y = "it is " >> add(add("also ", midw()))
+#     assert isinstance(y, str) and y == 'it is also evaluated'

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -21,7 +21,7 @@ def test_function():
     ret = func([1], 0)
     assert ret == 1
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, x):
         return x
 
@@ -34,7 +34,7 @@ def test_function_deep():
     def func(data, x):
         return {key: data[key] for key in x}
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, keys):
         return keys
 
@@ -60,35 +60,35 @@ def test_function_deep():
     assert ret == {'a': 1, 'b': 2}
 
 def test_function_called_in_normal_way():
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data, x):
         return data[x]
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, x):
         return x
 
     r = [1, 2] >> verb(func(0) + 1)
     assert r == 2
 
-    r = func(1, _env='piping').evaluate([0, 1])
+    r = func(1, _env='piping')([0, 1])
     assert r == 1
 
 def test_context():
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data, x):
         return data * x
 
-    @register_func(None)
+    @register_func(None, context=Context.EVAL)
     def func2(x):
         return x * 10
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, x):
         return data + x
 
-    ata = DataEnv(100, 'other')
     data = DataEnv(2)
+    data2 = DataEnv(100, 'other')
 
     y = verb(2)
     assert y == 4
@@ -127,11 +127,11 @@ def test_context():
         y = verb(2)
 
 def test_in_lambda():
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data, x):
         return data * x
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, func):
         return func(data)
 
@@ -149,20 +149,20 @@ def test_register_contexts_for_diff_cls():
     def _(data, x):
         return data[x]
 
-    @func.register(str)
+    @func.register(str, context=Context.EVAL)
     def _(data, x):
         return data + x
 
-    x = func(f[1], _env='piping').evaluate([2, 3])
+    x = func(f[1], _env='piping')([2, 3])
     assert x == [2, 3] * 3
 
-    x = func(f['a'], _env='piping').evaluate({'a': 1})
+    x = func(f['a'], _env='piping')({'a': 1})
     assert x == 1
 
-    x = func(f[1], _env='piping').evaluate((1, 2, 3))
+    x = func(f[1], _env='piping')((1, 2, 3))
     assert x == 2
 
-    x = func(f[1], _env='piping').evaluate('abc')
+    x = func(f[1], _env='piping')('abc')
     assert x == 'abcb'
 
 def test_unregister():
@@ -185,7 +185,7 @@ def test_unregister():
 
 def test_args_kwargs_have_expr():
     f = Symbolic()
-    @register_func(None)
+    @register_func(None, context=Context.EVAL)
     def func(x):
         return x
 
@@ -198,7 +198,7 @@ def test_args_kwargs_have_expr():
     with pytest.raises(ValueError):
         func(x=f[0])
 
-    @register_func
+    @register_func(context=Context.EVAL)
     def func2(data, x):
         return x
 
@@ -211,11 +211,11 @@ def test_func_called_in_different_envs():
     def verb(data, x):
         return x + 1
 
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data, x):
         return x + 2
 
-    @register_func(None)
+    @register_func(None, context=Context.EVAL)
     def func_no_data(x):
         return x + 4
 
@@ -252,15 +252,15 @@ def test_verb_arg_only():
     def verb(data, x):
         return x + 1
 
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data, x):
         return x + 2
 
-    @register_func(verb_arg_only=True)
+    @register_func(context=Context.EVAL, verb_arg_only=True)
     def func2(data, x):
         return x + 4
 
-    @register_func(None, verb_arg_only=True)
+    @register_func(None, context=Context.EVAL, verb_arg_only=True)
     def func3(x):
         return x + 8
 
@@ -299,7 +299,7 @@ def test_extra_contexts():
 
 def test_extra_contexts_error():
     f = Symbolic()
-    @register_func(extra_contexts={'nosucharg': Context.SELECT})
+    @register_func(context=Context.EVAL, extra_contexts={'nosucharg': Context.SELECT})
     def func(data, x): ...
 
     with pytest.raises(KeyError, match='No such argument'):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -2,7 +2,7 @@ import pytest
 
 from collections import OrderedDict
 import contextvars
-from pipda.utils import DATA_CONTEXTVAR_NAME, DataContext, functype, unregister
+from pipda.utils import DATA_CONTEXTVAR_NAME, DataEnv, functype, unregister
 
 from pipda.verb import Verb
 from pipda import *
@@ -87,8 +87,8 @@ def test_context():
     def verb(data, x):
         return data + x
 
-    ata = DataContext(100, 'other')
-    data = DataContext(2)
+    ata = DataEnv(100, 'other')
+    data = DataEnv(2)
 
     y = verb(2)
     assert y == 4

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -15,8 +15,9 @@ def test_operator():
 
     op = f['a'] + f['b']
     assert isinstance(op, Operator)
-    # x = op.evaluate(d, Context.UNSET) # not affected
-    # assert x == 3
+
+    x = op(d, Context.EVAL.value) # not affected
+    assert x == 3
 
 def test_operator_nosuch():
     with pytest.raises(ValueError):
@@ -36,6 +37,15 @@ def test_register():
         def add(self, a, b):
             return a - b
 
+        @Operator.set_context(context=Context.EVAL)
+        def mul(self, a, b):
+            return a * b
+
+        @Operator.set_context(context=Context.EVAL,
+                              extra_contexts={'a': Context.SELECT})
+        def sub(self, a, b):
+            return a * b
+
     register_operator(A)
 
     f = Symbolic()
@@ -45,7 +55,15 @@ def test_register():
         return x
 
     d = {'a': 1, 'b': 2}
-    ret = d >> verb(f['a'] - f['b'])
+    ret = d >> verb(f['a'] // f['b'])
+    assert ret == 0
+
+    ret = d >> verb(f['a'] + f['b'])
     assert ret == -1
 
+    ret = d >> verb(f['a'] * f['b'])
+    assert ret == 2
+
+    ret = d >> verb(f['a'] - f['b'])
+    assert ret == 'aa'
 

--- a/tests/test_pipda.py
+++ b/tests/test_pipda.py
@@ -253,12 +253,12 @@ class TestCase(unittest.TestCase):
     def test_proxy_compiler_set_data(self):
         X = Symbolic()
 
-        @register_verb(FunctionType, context=None)
+        @register_verb(FunctionType, context=Context.PENDING)
         def add1(data, arg):
             arg = evaluate_expr(arg, data, context=Context.EVAL)
             return data.a + arg
 
-        @register_verb(FunctionType, context=None)
+        @register_verb(FunctionType, context=Context.PENDING)
         def add2(data, arg):
             arg = evaluate_expr(arg, d2, Context.EVAL)
             return data.a + arg
@@ -277,7 +277,7 @@ class TestCase(unittest.TestCase):
     def test_proxy_compiler_custom(self):
         X = Symbolic()
 
-        @register_verb(FunctionType, context=None)
+        @register_verb(FunctionType, context=Context.PENDING)
         def add(data, arg):
             arg = evaluate_expr(arg, data, Context.EVAL) * 10
             return data.a + arg
@@ -390,7 +390,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(r.data, {'a': 6, 'b': 2})
 
     def test_original_unaffected(self):
-        @register_func(int)
+        @register_func((int, str))
         def func(data):
             return data
         @register_verb

--- a/tests/test_pipda.py
+++ b/tests/test_pipda.py
@@ -14,7 +14,7 @@ class TestCase(unittest.TestCase):
             return [[dat for dat in data if dat < num],
                     [dat for dat in data if dat > num]]
 
-        @register_verb(list)
+        @register_verb(list, context=Context.EVAL)
         def add(data, num):
             if not isinstance(num, int):
                 num = list(num)
@@ -22,7 +22,7 @@ class TestCase(unittest.TestCase):
                 num = [num] * len(data)
             return [dat + num[i] for i, dat in enumerate(data)]
 
-        @add.register(int)
+        @add.register(int, context=Context.EVAL)
         def _(data, num):
             return data + num
 
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
     def test_int(self):
         X = Symbolic()
 
-        @register_verb(int)
+        @register_verb(int, context=Context.EVAL)
         def add(data, num):
             """Split a list into two lists by one of the numbers in the list"""
             return data + num
@@ -54,19 +54,19 @@ class TestCase(unittest.TestCase):
         X = Symbolic()
         self.assertEqual(repr(X), '<Symbolic:X>')
 
-        @register_verb(dict)
+        @register_verb(dict, context=Context.EVAL)
         def filter(data, keys):
             return {key: val for key, val in data.items() if key in keys}
 
-        @register_verb(dict)
+        @register_verb(dict, context=Context.EVAL)
         def length(data):
             return data.__len__()
 
-        @register_func
+        @register_func(context=Context.EVAL)
         def starts_with(data, prefix):
             return [key for key in data if key.startswith(prefix)]
 
-        @register_func()
+        @register_func(context=Context.EVAL)
         def ends_with(data, suffix):
             return [key for key in data if key.endswith(suffix)]
 
@@ -161,19 +161,19 @@ class TestCase(unittest.TestCase):
 
     def test_unsupported_type_for_func(self):
         X = Symbolic()
-        @register_verb(int)
+        @register_verb(int, context=Context.EVAL)
         def add(data, other):
             return data + other
 
-        @add.register(float)
+        @add.register(float, context=Context.EVAL)
         def _(data, other):
             return data * other
 
-        @register_func(int)
+        @register_func(int, context=Context.EVAL)
         def one(data):
             return 1
 
-        @register_func
+        @register_func(context=Context.EVAL)
         def two(data):
             return 2
 
@@ -195,7 +195,7 @@ class TestCase(unittest.TestCase):
     def test_operators(self):
         X = Symbolic()
 
-        @register_verb(int)
+        @register_verb(int, context=Context.EVAL)
         def add(data, arg):
             return data + arg
 
@@ -290,19 +290,19 @@ class TestCase(unittest.TestCase):
 
     def test_call_other_verbs_funcs(self):
         X = Symbolic()
-        @register_verb(int)
+        @register_verb(int, context=Context.EVAL)
         def add(data, other):
             return data + other
 
-        @register_verb(int)
+        @register_verb(int, context=Context.EVAL)
         def mul(data, other):
             return data * add(data, other)
 
-        @register_func
+        @register_func(context=Context.EVAL)
         def neg(data, num):
             return -num
 
-        @register_func
+        @register_func(context=Context.EVAL)
         def double_neg(data, num):
             return neg(data, num) * 2
 
@@ -317,12 +317,12 @@ class TestCase(unittest.TestCase):
 
     def test_register_multiple(self):
         X = Symbolic()
-        @register_verb
+        @register_verb(context=Context.EVAL)
         def add(data, other):
             return 0
 
-        @add.register(int)
-        @add.register(float)
+        @add.register(int, context=Context.EVAL)
+        @add.register(float, context=Context.EVAL)
         def _(data, other):
             return data + other
 
@@ -393,7 +393,7 @@ class TestCase(unittest.TestCase):
         @register_func((int, str))
         def func(data):
             return data
-        @register_verb
+        @register_verb(context=Context.EVAL)
         def verb(data, x):
             return x
 

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -43,7 +43,7 @@ def test_plain_context_unset():
 
     m = mean([1, 2])
     assert m == 1.5
-    m = mean([1, 2], _calling_type='piping').evaluate([1, 2])
+    m = mean([1, 2], _env='piping').evaluate([1, 2])
     assert m == 1.5
 
     d = {'a': 1, 'b': 2}

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -5,11 +5,11 @@ from pipda.function import *
 from pipda import register_verb, Symbolic
 
 def test_plain_function():
-    @register_func(None)
+    @register_func(None, context=Context.EVAL)
     def mean(x):
         return float(sum(x)) / float(len(x))
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def mutate(data, **kwds):
         for k, v in kwds.items():
             data[k] = v
@@ -33,9 +33,9 @@ def test_plain_context_unset():
     #                    match='Common functions cannot be registered'):
     #     register_func(None, func=mean, context=Context.UNSET)
 
-    mean = register_func(None, func=mean)
+    mean = register_func(None, context=Context.EVAL, func=mean)
 
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def mutate(data, **kwds):
         for k, v in kwds.items():
             data[k] = v
@@ -43,7 +43,7 @@ def test_plain_context_unset():
 
     m = mean([1, 2])
     assert m == 1.5
-    m = mean([1, 2], _env='piping').evaluate([1, 2])
+    m = mean([1, 2], _env='piping')([1, 2])
     assert m == 1.5
 
     d = {'a': 1, 'b': 2}

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -2,7 +2,7 @@ import pytest
 
 from pipda.utils import evaluate_expr
 from pipda.function import *
-from pipda import register_verb, Symbolic
+from pipda import register_verb, Symbolic, Context
 
 def test_plain_function():
     @register_func(None, context=Context.EVAL)

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -7,28 +7,28 @@ def test_symbolic():
     f = Symbolic()
     assert isinstance(f.a, Reference)
     assert isinstance(f['a'], Reference)
-    assert f.evaluate(1) == 1
+    assert f(1) == 1
     assert f.__index__() is None
 
 def test_reference():
     f = Symbolic()
-    assert f.a.evaluate(1, ContextSelect()) == 'a'
+    assert f.a(1, ContextSelect()) == 'a'
     assert repr(f.a) == "DirectRefAttr(parent=<Symbolic:f>, ref='a')"
 
     with pytest.raises(NotImplementedError):
-        f.a.evaluate(1, ContextMixed())
+        f.a(1, ContextMixed())
     with pytest.raises(NotImplementedError):
-        f['a'].evaluate(1, ContextMixed())
+        f['a'](1, ContextMixed())
 
-    assert f['a'].evaluate(1, ContextSelect()) == 'a'
-    assert f['a'].evaluate({'a': 2}, ContextEval()) == 2
+    assert f['a'](1, ContextSelect()) == 'a'
+    assert f['a']({'a': 2}, ContextEval()) == 2
     # assert isinstance(f.a.evaluate(1, None), Reference)
     obj = lambda: 0
     obj.a = obj
     obj.b = 2
-    assert f.a.b.evaluate(obj, ContextEval()) == 2
+    assert f.a.b(obj, ContextEval()) == 2
     data = {'a': {'a': 2}}
-    assert f['a']['a'].evaluate(data, ContextEval()) == 2
+    assert f['a']['a'](data, ContextEval()) == 2
 
     # with pytest.raises(TypeError):
-    assert f[1].evaluate(0, ContextSelect()) == 1
+    assert f[1](0, ContextSelect()) == 1

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -23,10 +23,19 @@ def test_reference():
     assert f['a'](1, ContextSelect()) == 'a'
     assert f['a']({'a': 2}, ContextEval()) == 2
     # assert isinstance(f.a.evaluate(1, None), Reference)
+
     obj = lambda: 0
     obj.a = obj
     obj.b = 2
     assert f.a.b(obj, ContextEval()) == 2
+    # keywords
+    obj.ref = 3
+    obj.parent = 4
+    assert f.ref(obj, ContextEval()) == 3
+    assert f.parent(obj, ContextEval()) == 4
+
+
+
     data = {'a': {'a': 2}}
     assert f['a']['a'](data, ContextEval()) == 2
 

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -75,7 +75,7 @@ def test_context_unset():
             self.used.append(ref)
             return super().getattr(data, ref)
 
-    @register_verb(context=Context.UNSET)
+    @register_verb(context=Context.PENDING)
     def verb(data, x):
         mycontext = MyContext()
 
@@ -125,7 +125,7 @@ def test_diff_contexts_for_diff_types():
     def _(data, x):
         return data + type(data)([x])
 
-    @verb.register(int, context=Context.UNSET)
+    @verb.register(int, context=Context.PENDING)
     def _(data, x):
         return verb([data], x)
 

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -1,6 +1,6 @@
 import contextvars
 from pipda.symbolic import Reference
-from pipda.utils import DATA_CONTEXTVAR_NAME, DataContext, functype, unregister
+from pipda.utils import DATA_CONTEXTVAR_NAME, DataEnv, functype, unregister
 from pipda.context import ContextEval
 import pytest
 from pipda import *
@@ -102,7 +102,7 @@ def test_context():
     def verb(data, x):
         return data + x
 
-    data = DataContext(12)
+    data = DataEnv(12)
     y = verb(3)
     assert y == 15
 

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -23,10 +23,10 @@ def test_verb():
     assert ret == [1,2]
 
 def test_evaluated():
-    v = Verb(round, ContextEval(), (1, ), {})
+    v = Verb(round, (1, ), {})
     assert v.args == (1, )
     assert v.kwargs == {}
-    assert v.evaluate(1.123) == 1.1
+    assert v(1.123, Context.EVAL.value) == 1.1
 
 def test_register_piping_sign():
     assert Verb.CURRENT_SIGN == '>>'
@@ -43,7 +43,7 @@ def test_register_piping_sign_inexisting_method():
 
 
 def test_only_type():
-    @register_verb(int)
+    @register_verb(int, context=Context.EVAL)
     def verb(data, x):
         return data + x
 
@@ -53,7 +53,7 @@ def test_only_type():
     with pytest.raises(NotImplementedError):
         '1' >> verb('2')
 
-    @verb.register(str)
+    @verb.register(str, context=Context.EVAL)
     def _(data, x):
         return data + x + '0'
 
@@ -89,7 +89,7 @@ def test_context_unset():
     assert used_refs == ['a']
 
 def test_node_na():
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, x):
         return data + x
 
@@ -98,10 +98,11 @@ def test_node_na():
         assert verb(1, 1) == 2
 
 def test_context():
-    @register_verb
+    @register_verb(context=Context.EVAL)
     def verb(data, x):
         return data + x
 
+    data0 = DataEnv(100, 'whatever')
     data = DataEnv(12)
     y = verb(3)
     assert y == 15
@@ -121,7 +122,7 @@ def test_diff_contexts_for_diff_types():
         ret[x] = data[x] * 2
         return ret
 
-    @verb.register((list, tuple)) # eval
+    @verb.register((list, tuple), context=Context.EVAL) # eval
     def _(data, x):
         return data + type(data)([x])
 
@@ -163,7 +164,7 @@ def test_verb_as_arg():
     y = [1,2] >> add([lenof([lenof(f)])])
     assert y == [1, 2, 1]
 
-    @register_func
+    @register_func(context=Context.EVAL)
     def func(data):
         return len(data)
 

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -181,6 +181,31 @@ def test_unregister():
     assert unregister(registered) is orig
     assert functype(registered) == 'verb'
 
+def test_keyword_attr():
+    @register_verb(context=Context.EVAL)
+    def prod(data, *args):
+        ret = 1
+        for arg in args:
+            ret *= arg
+        return ret
+
+    data = lambda: 0
+    data.func = 2
+    data.datarg = 3
+    data.args = 4
+    data.kwargs = 5
+    data.parent = 6
+    data.ref = 7
+    data.data = 8
+    data.op = 9
+
+    f = Symbolic()
+    ret = data >> prod(
+        f.func, f.datarg, f.args, f.kwargs,
+        f.parent, f.ref, f.data, f.op
+    )
+    assert ret == 362880
+
 def test_astnode_fail_warning():
     # default
     @register_func(context=Context.SELECT)

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -220,3 +220,15 @@ def test_astnode_fail_warning():
         assert func([1,2], 1) == 2
     assert len(record) == 0
     register_func.astnode_fail_warning = True
+
+def test_inplace_pipe():
+
+    @register_verb(context=Context.SELECT)
+    def verb(data, x, y):
+        copied = data[:]
+        copied[x] = y
+        return copied
+
+    x = [1,2,3]
+    x >>= verb(1,4)
+    assert x == [1,4,3]

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -179,3 +179,18 @@ def test_unregister():
 
     assert unregister(registered) is orig
     assert functype(registered) == 'verb'
+
+def test_astnode_fail_warning():
+    # default
+    @register_func(context=Context.SELECT)
+    def func(data, x):
+        return data[x]
+
+    with pytest.warns(UserWarning):
+        assert func([1,2], 1) == 2
+
+    register_func.astnode_fail_warning = False
+    with pytest.warns(None) as record:
+        assert func([1,2], 1) == 2
+    assert len(record) == 0
+    register_func.astnode_fail_warning = True

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -9,7 +9,7 @@ from pipda.verb import *
 def test_verb():
     f = Symbolic()
 
-    @register_verb
+    @register_verb(context=Context.SELECT)
     def verb(data, x):
         return data[x]
 


### PR DESCRIPTION
- Allow verb/function called directly with Expression objects as arguments
- Allow context passed to _context argument of function to be registered
- Add astnode_fail_warning to register_verb/func to whether warn when ast node not be able to detect
- Add verb_arg_only for register_func to restrict registered func to be just an argument of a verb
- Allow extra_contexts for specific arguments for register_verb/func
- Add debug for evaluating
- Allow inplace piping
