### PR TITLE
0.2.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+## 0.2.6
+- Let `Symbolic.__getitem__` return `DirectRefItem` instead of `ReferenceItem`
+
 ## 0.2.5
 - Allow custom evaluation for objects in verb arguments.
 

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -10,4 +10,4 @@ from .utils import (
 from .context import Context, ContextBase
 from .operator import Operator, register_operator
 
-__version__ = '0.2.5'
+__version__ = '0.2.6'

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -98,7 +98,7 @@ class Symbolic(Expression):
 
     def __getitem__(self, item: Any) -> Any:
         """Create a DirectRefItem object"""
-        return ReferenceItem(self, item)
+        return DirectRefItem(self, item)
 
     def __repr__(self) -> str:
         return f"<Symbolic:{self.__varname__}>"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.2.5"
+version = "0.2.6"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ readme = ''
 setup(
     long_description=readme,
     name='pipda',
-    version='0.2.5',
+    version='0.2.6',
     description='A framework for data piping in python',
     python_requires='==3.*,>=3.7.0',
     author='pwwang',

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -153,7 +153,7 @@ def test_debug(caplog):
     logs = caplog.text.splitlines()
     assert "Evaluating Verb(func='test_debug.<locals>.verb') with context <ContextEval" in logs[0]
     assert "Evaluating Function(func='test_debug.<locals>.func1') with context <ContextEval" in logs[1]
-    assert "Evaluating ReferenceItem(parent=<Symbolic:f>, ref=2) with context <ContextEval" in logs[2]
+    assert "Evaluating DirectRefItem(parent=<Symbolic:f>, ref=2) with context <ContextEval" in logs[2]
     assert "Evaluating Function(func='test_debug.<locals>.func2') with context <ContextSelect" in logs[3]
     assert "Evaluating Function(func='test_debug.<locals>.func1') with context <ContextSelect" in logs[4]
-    assert "Evaluating ReferenceItem(parent=<Symbolic:f>, ref=4) with context <ContextSelect" in logs[5]
+    assert "Evaluating DirectRefItem(parent=<Symbolic:f>, ref=4) with context <ContextSelect" in logs[5]


### PR DESCRIPTION
- Let `Symbolic.__getitem__` return `DirectRefItem` instead of `ReferenceItem`