### PR TITLE
0.4.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,6 @@
+## 0.4.3
+- Avoid raising exception for `varname()` to get the name of `Symbolic` object.
+
 ## 0.4.2
 - Make Function property private thus accessiable to `getattr()` (otherwise returns an `Expression` object)
 - Give better repr for Function when func is an Expression object.

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -13,4 +13,4 @@ from .register import (
     unregister,
 )
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -100,7 +100,7 @@ class Symbolic(Expression):
 
     def __init__(self, name: str = None):
         """Construct a Symbolic object"""
-        self.__name = name or varname()
+        self.__name = name or varname(raise_exc=False) or 'f'
 
     def __getattr__(self, name: str) -> Any:
         """Create a DirectRefAttr object"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.4.2"
+version = "0.4.3"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if os.path.exists(readme_path):
 setup(
     long_description=readme,
     name='pipda',
-    version='0.4.2',
+    version='0.4.3',
     description='A framework for data piping in python',
     python_requires='==3.*,>=3.7.0',
     author='pwwang',


### PR DESCRIPTION
- Avoid raising exception for `varname()` to get the name of `Symbolic` object.