### PR TITLE
0.5.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,31 @@
+## 0.5.1
+
+- Remove abstract property `name` from contexts (`name` is no longer a required property to subclass `ContextBase`)
+- Allow meta data of context to be passed down
+  ```python
+  from pipda import Symbolic, register_func, register_verb, evaluate_expr
+  from pipda.context import Context, ContextEval
+
+  f = Symbolic()
+
+  @register_func(None, context=Context.SELECT)
+  def wrapper(x):
+    return x
+
+  @register_func(None, context=Context.EVAL)
+  def times_meta(x, _context=None):
+    return x * _context.meta["val"]
+
+  @register_verb(dict, context=ContextEval({"val": 10}))
+  def add(x, y):
+    return x["a"] + y
+
+  # metadata passed down to times_meta
+  {"a": 1} >> add(wrapper(use_meta(f["a"])))
+  # 12
+  ```
+
+
 ## 0.5.0
 - Stringify `Expression` objects reasonably
   ```

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -12,4 +12,4 @@ from .register import (
     unregister,
 )
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/pipda/context.py
+++ b/pipda/context.py
@@ -29,6 +29,7 @@ class ContextBase(ABC):  # pragma: no cover
     - `ref` here defines how the reference/item in `f.item` is evaluated.
         Since we could do `f[f.A]`.
     """
+
     def __init__(self, meta: Mapping[str, Any] = None):
         """Meta data is carring down"""
         self.meta = meta or {}
@@ -44,7 +45,13 @@ class ContextBase(ABC):  # pragma: no cover
     def update_meta_from(self, other_context: "ContextBase") -> None:
         """Update meta data from other context"""
         if other_context is not None:
-            self.meta.update(other_context.meta)
+            self.meta.update(
+                {
+                    key: mval
+                    for key, mval in other_context.meta.items()
+                    if key not in self.meta
+                }
+            )
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} @ {hex(id(self))}>"
@@ -106,11 +113,15 @@ class ContextPending(ContextBase):
 
     def getattr(self, parent: Any, ref: str) -> str:
         """Get the `ref` directly, regardless of `data`"""
-        raise NotImplementedError("Pending context cannot be used to evaluate.")
+        raise NotImplementedError(
+            "Pending context cannot be used to evaluate."
+        )
 
     def getitem(self, parent: Any, ref: Any) -> Any:
         """Get the `ref` directly, which is already evaluated by `f[ref]`"""
-        raise NotImplementedError("Pending context cannot be used to evaluate.")
+        raise NotImplementedError(
+            "Pending context cannot be used to evaluate."
+        )
 
 
 class ContextMixed(ContextBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.5.0"
+version = "0.5.1"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,20 +4,17 @@ from pipda.context import *
 
 def test_context_select():
     cs = ContextSelect()
-    assert cs.name == 'select'
     assert cs.getattr(None, 'a') == 'a'
     assert cs.getitem(None, 1) == 1
 
 def test_context_eval():
     ce = ContextEval()
     l = []
-    assert ce.name == 'eval'
     assert ce.getattr(l, '__len__') == l.__len__
     assert ce.getitem([1 ,2], 0) == 1
 
 def test_context_pending():
     cp = ContextPending()
-    assert cp.name == 'pending'
     with pytest.raises(NotImplementedError):
         cp.getattr(None, 'a')
     with pytest.raises(NotImplementedError):
@@ -25,7 +22,6 @@ def test_context_pending():
 
 def test_context_mixed():
     cm = ContextMixed()
-    assert cm.name == 'mixed'
     with pytest.raises(NotImplementedError):
         cm.getattr(None, 'a')
     with pytest.raises(NotImplementedError):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -23,9 +23,10 @@ class MyOperator(Operator):
 
 @pytest.fixture
 def install_operator():
+    print('Register myoperator')
     register_operator(MyOperator)
     yield
-    Operator.OPERATOR = Operator
+    Operator.REGISTERED = Operator
 
 
 def test_operator(f, iden2):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
-from pipda.context import Context
+from pipda.context import Context, ContextEval, ContextSelect
 import pytest
 
 import sys
 from executing import Source
 from pipda import register_func
+from pipda.function import Function
 from pipda.utils import *
 from pipda.utils import (
     _get_piping_verb_node,
@@ -142,3 +143,15 @@ def test_assume_all_piping(f, add2, iden_func):
     assert out == 3
 
 
+def test_meta_carried_down():
+    from pipda.operator import Operator
+    print(Operator.REGISTERED)
+    context = ContextEval({"a": 1})
+
+    @register_func(None, context=None)
+    def get_context(_context=None):
+        return _context.meta["a"]
+
+    expr = Function(get_context, (), {}, False)
+    out = evaluate_expr(expr + 2, None, context)
+    assert out == 3


### PR DESCRIPTION

- Remove abstract property `name` from contexts (`name` is no longer a required property to subclass `ContextBase`)
- Allow meta data of context to be passed down
  ```python
  from pipda import Symbolic, register_func, register_verb, evaluate_expr
  from pipda.context import Context, ContextEval

  f = Symbolic()

  @register_func(None, context=Context.SELECT)
  def wrapper(x):
    return x

  @register_func(None, context=Context.EVAL)
  def times_meta(x, _context=None):
    return x * _context.meta["val"]

  @register_verb(dict, context=ContextEval({"val": 10}))
  def add(x, y):
    return x["a"] + y

  # metadata passed down to times_meta
  {"a": 1} >> add(wrapper(use_meta(f["a"])))
  # 12
  ```