### PR TITLE
0.5.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+## 0.5.2
+
+- Add `level` argument to context.getitem()/getattr() so that the expression level can be used in evaluation;
+- Add `eval_symbolic()` to context to allow evaluate Symbolic objects in different ways.
+
 ## 0.5.1
 
 - Remove abstract property `name` from contexts (`name` is no longer a required property to subclass `ContextBase`)

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -12,4 +12,4 @@ from .register import (
     unregister,
 )
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/pipda/context.py
+++ b/pipda/context.py
@@ -34,12 +34,15 @@ class ContextBase(ABC):  # pragma: no cover
         """Meta data is carring down"""
         self.meta = meta or {}
 
+    def eval_symbolic(self, data: Any) -> Any:
+        return data
+
     @abstractmethod
-    def getattr(self, parent: Any, ref: str) -> Any:
+    def getattr(self, parent: Any, ref: str, level: int) -> Any:
         """Defines how `f.A` is evaluated"""
 
     @abstractmethod
-    def getitem(self, parent: Any, ref: Any) -> Any:
+    def getitem(self, parent: Any, ref: Any, level: int) -> Any:
         """Defines how `f[item]` is evaluated"""
 
     def update_meta_from(self, other_context: "ContextBase") -> None:
@@ -83,11 +86,11 @@ class ContextSelect(ContextBase):
         evaluated by a context returned by `getref`
     """
 
-    def getattr(self, parent: Any, ref: str) -> str:
+    def getattr(self, parent: Any, ref: str, level: int) -> str:
         """Get the `ref` directly, regardless of `data`"""
         return ref
 
-    def getitem(self, parent: Any, ref: Any) -> Any:
+    def getitem(self, parent: Any, ref: Any, level: int) -> Any:
         """Get the `ref` directly, which is already evaluated by `f[ref]`"""
         return ref
 
@@ -99,11 +102,11 @@ class ContextEval(ContextBase):
     `f.A` is evaluated as `f.A` and `f[item]` is evaluated as `f[item]`
     """
 
-    def getattr(self, parent: Any, ref: str) -> Any:
+    def getattr(self, parent: Any, ref: str, level: int) -> Any:
         """How to evaluate `f.A`"""
         return getattr(parent, ref)
 
-    def getitem(self, parent: Any, ref: Any) -> Any:
+    def getitem(self, parent: Any, ref: Any, level: int) -> Any:
         """How to evaluate `f[item]`"""
         return parent[ref]
 
@@ -111,13 +114,13 @@ class ContextEval(ContextBase):
 class ContextPending(ContextBase):
     """Pending context"""
 
-    def getattr(self, parent: Any, ref: str) -> str:
+    def getattr(self, parent: Any, ref: str, level: int) -> str:
         """Get the `ref` directly, regardless of `data`"""
         raise NotImplementedError(
             "Pending context cannot be used to evaluate."
         )
 
-    def getitem(self, parent: Any, ref: Any) -> Any:
+    def getitem(self, parent: Any, ref: Any, level: int) -> Any:
         """Get the `ref` directly, which is already evaluated by `f[ref]`"""
         raise NotImplementedError(
             "Pending context cannot be used to evaluate."
@@ -128,12 +131,12 @@ class ContextMixed(ContextBase):
     """A mixed context, where the `*args` are evaluated with `ContextSelect`
     and `**args` are evaluated with `ContextEval`."""
 
-    def getattr(self, parent: Any, ref: str) -> None:
+    def getattr(self, parent: Any, ref: str, level: int) -> None:
         raise NotImplementedError(
             "Mixed context should be used via `.args` or `.kwargs`"
         )
 
-    def getitem(self, parent: Any, ref: Any) -> None:
+    def getitem(self, parent: Any, ref: Any, level: int) -> None:
         raise NotImplementedError(
             "Mixed context should be used via `.args` or `.kwargs`"
         )

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -68,7 +68,7 @@ class ReferenceAttr(Reference):
         super()._pipda_eval(data, context)
         parent = evaluate_expr(self._pipda_parent, data, context)
 
-        return context.getattr(parent, self._pipda_ref)
+        return context.getattr(parent, self._pipda_ref, self._pipda_level)
 
 
 class ReferenceItem(Reference):
@@ -83,7 +83,7 @@ class ReferenceItem(Reference):
         parent = evaluate_expr(self._pipda_parent, data, context)
         ref = evaluate_expr(self._pipda_ref, data, context.ref)
 
-        return context.getitem(parent, ref)
+        return context.getitem(parent, ref, self._pipda_level)
 
 
 class Symbolic(Expression):
@@ -117,4 +117,7 @@ class Symbolic(Expression):
 
     def _pipda_eval(self, data: Any, context: ContextBase = None) -> Any:
         """When evaluated, this should just return the data directly"""
-        return data
+        if context is None:
+            return data
+
+        return context.eval_symbolic(data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.5.1"
+version = "0.5.2"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,31 +1,43 @@
 import pytest
 
 from pipda.context import *
+from pipda import evaluate_expr, Symbolic
 
 def test_context_select():
     cs = ContextSelect()
-    assert cs.getattr(None, 'a') == 'a'
-    assert cs.getitem(None, 1) == 1
+    assert cs.getattr(None, 'a', 1) == 'a'
+    assert cs.getitem(None, 1, 1) == 1
 
 def test_context_eval():
     ce = ContextEval()
     l = []
-    assert ce.getattr(l, '__len__') == l.__len__
-    assert ce.getitem([1 ,2], 0) == 1
+    assert ce.getattr(l, '__len__', 1) == l.__len__
+    assert ce.getitem([1 ,2], 0, 1) == 1
+
+def test_user_context():
+    class MyContext(ContextEval):
+        def eval_symbolic(self, data):
+            return data * 2
+
+    ce = MyContext()
+    f = Symbolic()
+    out = evaluate_expr(f.__len__(), [1, 2], ce)
+    assert out == 4
+
 
 def test_context_pending():
     cp = ContextPending()
     with pytest.raises(NotImplementedError):
-        cp.getattr(None, 'a')
+        cp.getattr(None, 'a', 1)
     with pytest.raises(NotImplementedError):
-        cp.getitem(None, 'a')
+        cp.getitem(None, 'a', 1)
 
 def test_context_mixed():
     cm = ContextMixed()
     with pytest.raises(NotImplementedError):
-        cm.getattr(None, 'a')
+        cm.getattr(None, 'a', 1)
     with pytest.raises(NotImplementedError):
-        cm.getitem(None, 'a')
+        cm.getitem(None, 'a', 1)
     assert isinstance(cm.args, ContextSelect)
     assert isinstance(cm.kwargs, ContextEval)
 


### PR DESCRIPTION
- Add `level` argument to context.getitem()/getattr() so that the expression level can be used in evaluation;
- Add `eval_symbolic()` to context to allow evaluate Symbolic objects in different ways.