### PR TITLE
0.5.7

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,8 @@
+## 0.5.7
+
+- 🐛 Fix `f.x.mean()` evaluation in all-piping mode
+
+
 ## 0.5.6
 
 - 🚑 Fix context meta not recovered when error

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -12,4 +12,4 @@ from .register import (
     unregister,
 )
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -81,6 +81,15 @@ class Function(Expression):
         if isinstance(func, Expression):
             func = evaluate_expr(func, data, context)
 
+        if isinstance(func, Expression):
+            # If it is still an expression
+            # then context must be PENDING, this kind of expression can
+            # not be evaluated: f.x.mean()
+            # Then there is no such thing like dataarg, dispatching and
+            # extra_context
+            # We just pass it down until a context is given
+            return self
+
         dispatcher = _get_dispatcher(func, type(data))  # type: ignore
         func_context = getattr(dispatcher, "context", None)
         func_extra_contexts = getattr(dispatcher, "extra_contexts", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.5.6"
+version = "0.5.7"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]


### PR DESCRIPTION
- 🐛 Fix `f.x.mean()` evaluation in all-piping mode
