### PR TITLE
0.7.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.7.1
+
+- 🐛 Fix VerbCall `__str__`
+- ⚡️ Make Symbolic a singleton
+- 🐛 Allow general keyword arg for extra contexts
+- 🧱 Always enable `ast_fallback_arg`
+- 💥 Change the way verbs used as funcs
+
 ## 0.7.0
 
 - ♻️ Refactor to decrease complexity

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - 🐛 Allow general keyword arg for extra contexts
 - 🧱 Always enable `ast_fallback_arg`
 - 💥 Change the way verbs used as funcs
+- 🩹 Allow func passed directly to register_verb
 
 ## 0.7.0
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -104,7 +104,7 @@ def add(x, y):
 def sub(x, y):
     return x - y
 
-@register_verb(int, ast_fallback_arg=True)
+@register_verb(int)
 def mul(x, y):
     return x * y
 

--- a/docs/verbs.md
+++ b/docs/verbs.md
@@ -35,9 +35,9 @@ def plus(data, n):
 plus(n=2)  # a VerbCall object awaiting data for evaluation
 ```
 
-## Expression as data
+## Using as functions
 
-Verbs can take `Expression` object when they are used as another verb.
+When the first argument is an `Expression` then the verbs work as functions
 
 ```python
 f = Symbolic()
@@ -50,10 +50,10 @@ def sub(data, n):
 def add(data, n):
     return data + n
 
-# sub: f*2 -> 20, n=f+1=21    -> -1
-# note that second f refers to the data of its verb, which is f*2 = 20
-# add: 10 + -1 = 9
-10 >> add(n=sub(f*2, n=f+1))  # 9
+# sub: f*2 -> 20, n=f+1=11    -> 9
+# note that second f still refers to the parent data, which is 10
+# add: 10 + 9 = 19
+10 >> add(n=sub(f*2, n=f+1))  # 19
 ```
 
 ## Dispatching other types

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -7,4 +7,4 @@ from .symbolic import Symbolic
 from .utils import evaluate_expr
 from .verb import Verb, VerbCall, register_verb, register_piping
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -12,6 +12,7 @@ from .expression import Expression
 if TYPE_CHECKING:
     from inspect import BoundArguments
     from .context import ContextType
+    from .verb import Verb
 
 
 class FunctionCall(Expression):
@@ -26,7 +27,7 @@ class FunctionCall(Expression):
 
     def __init__(
         self,
-        func: Function | Expression,
+        func: Function | Verb | Expression,
         *args: Any,
         **kwargs: Any,
     ) -> None:

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -64,19 +64,14 @@ class FunctionCall(Expression):
                 },
             )
 
-        boundargs = func.bind_arguments(*self._pipda_args, **self._pipda_kwargs)
+        bound = func.bind_arguments(*self._pipda_args, **self._pipda_kwargs)
         context = func.context or context
-        args = (evaluate_expr(arg, data, context) for arg in boundargs.args)
-        kwargs = {
-            key: evaluate_expr(
-                val,
-                data,
-                func.extra_contexts.get(key, context)
-            )
-            for key, val in boundargs.kwargs.items()
-        }
+        for key, val in bound.arguments.items():
+            ctx = func.extra_contexts.get(key, context)
+            val = evaluate_expr(val, data, ctx)
+            bound.arguments[key] = val
 
-        return func.func(*args, **kwargs)
+        return func.func(*bound.args, **bound.kwargs)
 
 
 class Registered(ABC):
@@ -151,8 +146,6 @@ def register_func(
         func: The original function
         context: The context used to evaluate the arguments
         extra_contexts: Extra contexts to evaluate keyword arguments
-            Note that the arguments should be defined as keyword-only arguments
-            For example the argument `y` in `def fun(x, *, y): ...`
 
     Returns:
         A registered `Function` object, or a decorator if `func` is not given

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import Any, Type, TYPE_CHECKING
 
 from .expression import Expression
 
@@ -13,6 +13,15 @@ class Symbolic(Expression):
     In most cases it is used to construct the Reference objects.
     """
     _pipda_level = 0
+    _pipda_instance = None
+
+    def __new__(cls: Type[Symbolic]) -> Symbolic:
+        if cls._pipda_instance is not None:
+            return cls._pipda_instance
+
+        inst = super().__new__(cls)
+        cls._pipda_instance = inst
+        return inst
 
     def __str__(self) -> str:
         return ""

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -94,12 +94,10 @@ class Verb(Registered):
         dep: bool,
         expr_as_data: bool,
         ast_fallback: str,
-        ast_fallback_arg: bool,
     ) -> None:
         self.dep = dep
         self.expr_as_data = expr_as_data
         self.ast_fallback = ast_fallback
-        self.ast_fallback_arg = ast_fallback_arg
 
         def fallback(_data, *args, **kwargs):
             raise NotImplementedError(
@@ -161,10 +159,7 @@ class Verb(Registered):
             # Meaning data should never be passed explictly
             return VerbCall(self, *args, **kwargs)
 
-        if self.ast_fallback_arg:
-            ast_fallback = kwargs.pop("__ast_fallback", self.ast_fallback)
-        else:
-            ast_fallback = self.ast_fallback
+        ast_fallback = kwargs.pop("__ast_fallback", self.ast_fallback)
 
         if is_piping_verbcall(self.func.__name__, ast_fallback):
             # data >> verb(...)
@@ -197,7 +192,6 @@ def register_verb(
     dep: bool = False,
     expr_as_data: bool = True,
     ast_fallback: str = "normal_warning",
-    ast_fallback_arg: bool = False,
 ) -> Callable[[Callable], Verb]:
     """Register a verb
 
@@ -222,9 +216,6 @@ def register_verb(
             piping_warning - Suppose piping call, but show a warning
             normal_warning - Suppose normal call, but show a warning
             raise - Raise an error
-        ast_fallback_arg - Whether to use `__ast_fallback` keyword argument
-            to indicate one of the above behaviors
-            If `__ast_fallback` is not provide, use value from `ast_fallback`
     """
     if not isinstance(types, Sequence):
         types = [types]
@@ -237,7 +228,6 @@ def register_verb(
         dep=dep,
         expr_as_data=expr_as_data,
         ast_fallback=ast_fallback,
-        ast_fallback_arg=ast_fallback_arg,
     )
 
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -46,8 +46,9 @@ class VerbCall(Expression):
         self._pipda_kwargs = kwargs
 
     def __str__(self) -> str:
+        strargs: List[str] = []
         if not self._pipda_func.dep:
-            strargs: List[str] = ["."]
+            strargs.append(".")
 
         funname = str(self._pipda_func)
         if self._pipda_args:

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -186,6 +186,7 @@ def register_verb(
     extra_contexts: Mapping[str, ContextType] = None,
     dep: bool = False,
     ast_fallback: str = "normal_warning",
+    func: Callable = None,
 ) -> Callable[[Callable], Verb]:
     """Register a verb
 
@@ -208,12 +209,23 @@ def register_verb(
             piping_warning - Suppose piping call, but show a warning
             normal_warning - Suppose normal call, but show a warning
             raise - Raise an error
+        func: The function works as a verb.
     """
+    if func is None:
+        return lambda fun: register_verb(
+            types=types,
+            context=context,
+            extra_contexts=extra_contexts or {},
+            dep=dep,
+            ast_fallback=ast_fallback,
+            func=fun,
+        )
+
     if not isinstance(types, Sequence):
         types = [types]
 
-    return lambda fun: Verb(
-        fun,
+    return Verb(
+        func,
         types=types,
         context=context,
         extra_contexts=extra_contexts or {},

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -187,7 +187,7 @@ def register_verb(
     dep: bool = False,
     ast_fallback: str = "normal_warning",
     func: Callable = None,
-) -> Callable[[Callable], Verb]:
+) -> Callable[[Callable], Verb] | Verb:
     """Register a verb
 
     Args:
@@ -212,7 +212,7 @@ def register_verb(
         func: The function works as a verb.
     """
     if func is None:
-        return lambda fun: register_verb(
+        return lambda fun: register_verb(  # type: ignore
             types=types,
             context=context,
             extra_contexts=extra_contexts or {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.7.0"
+version = "0.7.1"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -25,7 +25,7 @@ def test_user_context():
     ce = MyContext()
     f = Symbolic()
     out = evaluate_expr(f[1], [1, 2], ce)
-    assert out == 4
+    assert out == 4 and isinstance(out, int)
 
 
 def test_context_pending():

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -51,7 +51,7 @@ def test_empty_args():
         return 10
 
     out = fun()
-    assert out == 10
+    assert out == 10 and isinstance(out, int)
 
 
 def test_no_expr_args():
@@ -60,4 +60,4 @@ def test_no_expr_args():
         return x + y
 
     out = add(1, 2)
-    assert out == 3
+    assert out == 3 and isinstance(out, int)

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -31,14 +31,14 @@ def test_attr_eval():
     data.x = 10
 
     out = f.x._pipda_eval(data, Context.EVAL)
-    assert out == 10
+    assert out == 10 and isinstance(out, int)
 
 
 def test_item_eval():
     f = Symbolic()
 
     out = f["x"]._pipda_eval({"x": 10}, Context.EVAL)
-    assert out == 10
+    assert out == 10 and isinstance(out, int)
 
     # f[...] can also have expression inside
     class ContextTest(ContextEval):
@@ -47,7 +47,7 @@ def test_item_eval():
             return Context.SELECT.value
 
     out = f[f[0]]._pipda_eval([2, 1, 3], ContextTest())
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     out = f[f[0]]._pipda_eval([2, 1, 3], Context.EVAL)
-    assert out == 3
+    assert out == 3 and isinstance(out, int)

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -8,3 +8,9 @@ def test_symbolic():
     assert str(f) == ""
 
     assert f._pipda_eval(1) == 1
+
+
+def test_symbolic_singleton():
+    f = Symbolic()
+    g = Symbolic()
+    assert f is g

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,12 @@ def test_is_piping_verbcall_normal():
     a = 1 >> iden()
     assert a == 1 and isinstance(a, int)
 
+    @register_verb(int, ast_fallback="normal")
+    def iden2(x):
+        return x
+
+    # no warning
+    assert iden2(1) == 1 and isinstance(iden2(1), int)
 
 def test_is_piping_verbcall_piping():
 
@@ -113,29 +119,29 @@ def test_is_piping_verbcall_raise():
     assert a == 1 and isinstance(a, int)
 
 
-def test_is_piping_verbcall_fallback_arg():
+# def test_is_piping_verbcall_fallback_arg():
 
-    @register_verb(int, ast_fallback="raise", ast_fallback_arg=True)
-    def iden(x):
-        return x
+#     @register_verb(int, ast_fallback="raise")
+#     def iden(x):
+#         return x
 
-    assert iden(1, __ast_fallback="normal") == 1
-    assert isinstance(iden(1, __ast_fallback="normal"), int)
+#     assert iden(1, __ast_fallback="normal") == 1
+#     assert isinstance(iden(1, __ast_fallback="normal"), int)
 
-    assert 1 >> iden(__ast_fallback="piping") == 1
-    assert isinstance(1 >> iden(__ast_fallback="piping"), int)
+#     assert 1 >> iden(__ast_fallback="piping") == 1
+#     assert isinstance(1 >> iden(__ast_fallback="piping"), int)
 
-    with pytest.warns(VerbCallingCheckWarning):
-        assert (
-            iden(1, __ast_fallback="normal_warning") == 1
-            and isinstance(iden(1, __ast_fallback="normal_warning"), int)
-        )
+#     with pytest.warns(VerbCallingCheckWarning):
+#         assert (
+#             iden(1, __ast_fallback="normal_warning") == 1
+#             and isinstance(iden(1, __ast_fallback="normal_warning"), int)
+#         )
 
-    with pytest.warns(VerbCallingCheckWarning), pytest.raises(TypeError):
-        assert (1 >> iden(__ast_fallback="normal_warning")) == 1
+#     with pytest.warns(VerbCallingCheckWarning), pytest.raises(TypeError):
+#         assert (1 >> iden(__ast_fallback="normal_warning")) == 1
 
-    with pytest.raises(VerbCallingCheckError):
-        assert iden()  # fallback to raise
+#     with pytest.raises(VerbCallingCheckError):
+#         assert iden()  # fallback to raise
 
 
 def test_has_expr():

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -38,10 +38,13 @@ def test_extra_contexts():
         context=Context.EVAL,
         extra_contexts={'col': Context.SELECT},
     )
-    def subset(data, subdata, *, col):
+    def subset(data, subdata, col):
         return subdata[col]
 
     out = {"x": {"a": 1}} >> subset(f["x"], col=f.a)
+    assert out == 1 and isinstance(out, int)
+
+    out = {"x": {"a": 1}} >> subset(f["x"], f.a)
     assert out == 1 and isinstance(out, int)
 
 

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -42,7 +42,7 @@ def test_extra_contexts():
         return subdata[col]
 
     out = {"x": {"a": 1}} >> subset(f["x"], col=f.a)
-    assert out == 1
+    assert out == 1 and isinstance(out, int)
 
 
 def test_unregistered_types():
@@ -51,7 +51,7 @@ def test_unregistered_types():
         return len(data)
 
     out = [1, 2] >> length()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     with pytest.raises(NotImplementedError):
         (1, 2) >> length()
@@ -67,10 +67,10 @@ def test_register_more_types():
         return len(data) * 10
 
     out = [1, 2] >> length()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     out = (1, 2) >> length()
-    assert out == 20
+    assert out == 20 and isinstance(out, int)
 
 
 def test_register_more_types_inherit_context():
@@ -99,13 +99,13 @@ def test_register_more_types_inherit_context():
         return select(list(data), indices, plus=plus)
 
     out = [1, 2, 3, 4] >> select([f[0], f[2]], plus=f[0])
-    assert out == [2, 4]
+    assert out == [2, 4] and isinstance(out, list)
 
     out = (1, 2, 3, 4) >> select([f[0], f[2]], plus=f[0])
-    assert out == (2, 4)
+    assert out == (2, 4) and isinstance(out, tuple)
 
     out = MyList([1, 2, 3, 4]) >> select([f[0], f[2]], plus=f[0])
-    assert out == [2, 4]
+    assert out == [2, 4] and isinstance(out, list)
 
 
 def test_dependent_verb():
@@ -130,19 +130,19 @@ def test_dependent_verb():
     assert isinstance(out, VerbCall)
 
     out = length([1, 2])
-    assert out == 2
+    assert isinstance(out, VerbCall)
     out = length2([1, 2])
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     out = [1, 2] >> length()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
     out = [1, 2] >> length2()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     out = [1, 2, 3] >> times(length())
-    assert out == [3, 6, 9]
+    assert out == [3, 6, 9] and isinstance(out, list)
     out = [1, 2, 3] >> times(length2(f[:2]))
-    assert out == [2, 4, 6]
+    assert out == [2, 4, 6] and isinstance(out, list)
 
 
 def test_expr_as_data():
@@ -186,17 +186,17 @@ def test_register_piping():
         return x + 1
 
     out = 1 >> incre()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     register_piping("|")
     with pytest.raises(TypeError):
         1 >> incre()
     out = 1 | incre()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     register_piping(">>")
     out = 1 >> incre()
-    assert out == 2
+    assert out == 2 and isinstance(out, int)
 
     with pytest.raises(ValueError):
         register_piping("123")

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -148,7 +148,7 @@ def test_dependent_verb():
     assert out == [2, 4, 6] and isinstance(out, list)
 
 
-def test_expr_as_data():
+def test_as_func():
     f = Symbolic()
 
     @register_verb(dict, context=Context.EVAL)
@@ -167,6 +167,14 @@ def test_expr_as_data():
     out = {"a": 1, "b": 2, "c": 3} >> update(
         plus(
             {"a": 2, "b": f["c"]},
+            f["a"],  # 1 instead 2
+        )
+    )
+    assert out == {"a": 3, "b": 4, "c": 3}
+
+    out = {"a": 1, "b": 2, "c": 3} >> update(
+        plus(
+            {"a": 2, "b": 3},
             f["a"],  # 2 instead 1
         )
     )
@@ -203,3 +211,13 @@ def test_register_piping():
 
     with pytest.raises(ValueError):
         register_piping("123")
+
+
+def test_registered():
+
+    @register_verb(int)
+    def incre(x):
+        return x + 1
+
+    assert incre.registered(int)
+    assert not incre.registered(list)


### PR DESCRIPTION
- 🐛 Fix VerbCall `__str__`
- ⚡️ Make Symbolic a singleton
- 🐛 Allow general keyword arg for extra contexts
- 🧱 Always enable `ast_fallback_arg`
- 💥 Change the way verbs used as funcs
- 🩹 Allow func passed directly to register_verb