### PR TITLE
0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ pip install -U pipda
 
 ### Verbs
 
-Verbs are functions next to the piping sign (`>>`) receiving the data directly.
+- A verb is pipeable (able to be called like `data >> verb(...)`)
+- A verb is dispatchable by the type of its first argument
+- A verb evaluates other arguments using the first one
+- A verb is passing down the context and backend if not specified in the arguments
 
 ```python
 import pandas as pd
@@ -169,7 +172,7 @@ Here the trick is `f`. Like other packages, we introduced the `Symbolic` object,
 
 [https://pwwang.github.io/pipda/][19]
 
-See also [datar][6] for realcase usages.
+See also [datar][6] for real-case usages.
 
 [1]: https://github.com/machow/siuba
 [2]: https://github.com/kieferk/dfply

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install -U pipda
 - A verb is pipeable (able to be called like `data >> verb(...)`)
 - A verb is dispatchable by the type of its first argument
 - A verb evaluates other arguments using the first one
-- A verb is passing down the context and backend if not specified in the arguments
+- A verb is passing down the context if not specified in the arguments
 
 ```python
 import pandas as pd

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.10.0
+
+- 💥 Refactor the registered borrowed from `singledispatch`
+- ✨ Allow pipeable and dispatchable functions (related: pwwang/datar#148)
+- 💥 Change default ast_fallback to "piping_warning" for verbs
+- ✨ Allow to register multi-types at a time for dispatchable functions
+- ✨ Support backends
+- ✨ Allow register plain functions
+- ✅ Add level test for context
+- ✨ Make pipeable function work as a verb
+
 ## 0.9.0
 
 - ✨ Allow `__array_ufunc__` to be registered on Expression by `register_expr_array_func`

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,0 +1,54 @@
+# Backends
+
+Verbs and registered functions can be implemented for different backends. The dispatching is generally distinguishing different implementations. However, sometimes we want to use different implementations for the same type. In this case, we can use the `backend` argument to register the function for a specific backend.
+
+For example, we want to implement a function `rep` for different backends.
+
+```python
+from pipda import register_func
+
+@register_func(dispatchable="args")
+def rep(x, y):
+    raise NotImplementedError
+
+@rep.register(cls=int, backend="python")
+def _(x, y):
+    return [x] * y
+
+@rep.register(cls=int, backend="numpy")
+def _(x, y):
+    import numpy as np
+    return np.repeat(x, y)
+
+# Later registered backend has higher priority
+# But a warning will be shown since we have two implementations for int
+rep(1, 3)  # np.array([1, 1, 1])
+# Use __backend argument to specify the backend
+rep(1, 3, __backend="python")  # [1, 1, 1]
+```
+
+To eliminate the warning, we can also use the favored implementation for a backend:
+
+```python
+from pipda import register_func
+
+@register_func(dispatchable="args")
+def rep(x, y):
+    raise NotImplementedError
+
+@rep.register(cls=int, backend="python")
+def _(x, y):
+    return [x] * y
+
+@rep.register(cls=int, backend="numpy", favored=True)
+def _(x, y):
+    import numpy as np
+    return np.repeat(x, y)
+
+# Later registered backend has higher priority
+# No warnings anymore
+rep(1, 3)  # np.array([1, 1, 1])
+rep(1, 3, __backend="python")  # [1, 1, 1]
+```
+
+Verbs apply the same rule for backends.

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -87,16 +87,16 @@ def subset_and_update(data, *cols, **kwargs):
     Note that for `Context.PENDING`, we need to subclass `context.ContextPending`
     to keep expressions unevaluated.
 
-## Extra contexts
+## Contexts for keyword arguments
 
-We can set extra contexts for keyword-only arguments.
+We can set extra contexts for keyword arguments.
 
 ```python
 
 @register_verb(
     dict,
     context=Context.EVAL,
-    extra_contexts={"cols": Context.SELECT},
+    kw_context={"cols": Context.SELECT},
 )
 def subset_and_update(data, *, cols, **kwargs):
     data = {key: val for key, val in data.items() if key in cols}
@@ -117,3 +117,14 @@ def subset_and_update(data, *, cols, **kwargs):
 
     When registering another type(s) for a verb, contexts and extra contexts
     are inherited for the first ones that registered with `register_verb`
+
+
+!!! Tip
+
+    Each implementation for the registered verbs or functions can have its own
+    contexts. Specify them when registering the implementations.
+
+    ```python
+    <verb>.register(..., context=..., kw_context=...)
+    <func>.register(..., context=..., kw_context=...)
+    ```

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -1,43 +1,156 @@
 # Functions
 
-Functions cannot be used as verb arguments if they have expression arguments. Those arguments
-are not evaluated into real values yet. So we also need to turn the functions into expressions.
+For functions, we mean that the registered functions, rather than the python plain functions. Function calls are used as verb arguments, but they can be used independently as well, if no expressions is passed to the function.
 
-`Function`s can also take `context` and `extra_contexts`. If not provided, next avaiable context will be used.
+Functions share some features with verbs, such as that they could be pipeable and dispatchable as well. But they have a lot of differences as well. The biggest ones are that a function:
 
-## Registering functions
+- doesn't use the type of the first argument only to dispatch
+- doesn't pass the context down
+- doesn't evaluate other arguments using the first one (unless specified) but the data passed to the call from a verb, unless a data is piped in.
+
+## Register a function
+
+To register a function, use `register_func` function/decorator. Here are the arguments:
+
+- func: The generic function.
+    If `None` (not provided), this function will return a decorator.
+- cls: The default type to register for _default backend
+    if TypeHolder, it is a generic function, and not counted as a
+    real implementation.
+    For plain or non-dispatchable functions, specify a different type
+    than TypeHolder to indicate the func is a real implementation.
+- plain: If True, the function will be registered as a plain function,
+    which means it will be called without any evaluation of the
+    arguments. It doesn't support dispatchable and pipeable.
+- name: and
+- qualname: and
+- doc: and
+- module: The meta information about the function to overwrite `func`'s
+    or when it's not available from `func`
+- ast_fallback: What's the supposed way to call the func when
+    AST node detection fails.
+    - piping - Suppose this func is called like `data >> func(...)`
+    - normal - Suppose this func is called like `func(data, ...)`
+    - piping_warning - Suppose piping call, but show a warning
+    - normal_warning - Suppose normal call, but show a warning
+    - raise - Raise an error
+- dispatchable: If True, the function will be registered as a dispatchable
+    function, which means it will be dispatched using the types of
+    positional arguments.
+- dispatch_args: Which arguments to use for dispatching.
+    - "first" - Use the first argument
+    - "args" - Use all positional arguments
+    - "kwargs" - Use all keyword arguments
+    - "all" - Use all arguments
+- pipeable: If True, the function will work like a verb when a data is
+    piping in. If dispatchable, the first argument will be used to
+    dispatch the implementation.
+    The rest of the arguments will be evaluated using the data from
+    the first argument.
+- context: The context used to evaluate the rest arguments using the
+    first argument only when the function is pipeable and the data
+    is piping in.
+- kw_context: The context used to evaluate the keyword arguments
+
+## Plain functions
+
+One could register functions as plain functions, which means they will be called without any evaluation of the arguments. It doesn't support dispatchable and pipeable.
+
+The reason to allow plain functions is that we could have multiple implementations for different backends for plain functions.
+
+See [Backends](./backends) for more details.
+
+## Dispatchable functions
+
+One could register functions as dispatchable functions, which means they will be dispatched using the type of the first argument, the types of positional arguments, the types of of the keyword arguments, or the types of all arguments.
+
+The types are determined after the arguments are evaluated. One could specify the context for evaluation of the arguments. See [Contexts](./contexts) for more details. If not specified, the context passed down from the verb will be used. One could also specify the context for the function and kw_context for the keyword arguments.
+
+Once an implementation is found, the later arguments will be ignored. If no implementation is found, the default implementation (that raises `NotImplementedError`) will be used.
+
+### Dispatching by the type of the first argument
+
+Using the type of the first argument:
 
 ```python
-from pipda import register_func, register_verb, Context, Symbolic
+from pipda import register_func
 
-# @register_func(context=..., extra_contexts=...)
-@register_func
-def mean(x):
-    return sum(x) / len(x)
+@register_func(cls=int, dispatchable="first")
+def rep(x, y):
+    return x + y
+
+@rep.register(str)
+def _(x, y):
+    return x * y
+
+rep(1, 2)  # 3
+rep("a", 3)  # "aaa"
 ```
 
-## Usage of registered functions
-
-Using as a normal function:
+Using the types of the positional arguments:
 
 ```python
-mean([1, 2, 3])  # 2
+from pipda import register_func
+
+@register_func(cls=int, dispatchable="args")
+def rep(x, y):
+    return x * y
+
+@rep.register(str)
+def _(x, y):
+    return x + str(y)
+
+rep(1, 2)  # 2
+rep("a", 3)  # "a3"
+# Type of 2nd argument used
+rep([1], 2)  # [1, 1]
 ```
 
-Used as verb argument:
+Using the types of the keyword arguments:
 
 ```python
-f = Symbolic()
+from pipda import register_func
 
-@register_verb(list, context=Context.EVAL)
-def plus_each(data, n):
-    return [x + n for x in data]
+@register_func(cls=str, dispatchable="kwargs")
+def rep(x, y):
+    return x + y
 
-[1, 2, 3] >> plus_each(mean(f))  # [3, 4, 5]
+@rep.register(int)
+def _(x, y):
+    return x * y
+
+rep("1", y=2)  # 11
+rep("1", y="2")  # "12"
 ```
 
-Evaluating directly:
+Using the types of all arguments:
 
 ```python
-mean(f)._pipda_eval([1, 2, 3])  # 2
+from pipda import register_func
+
+@register_func(cls=str, dispatchable="kwargs")
+def rep(x, y):
+    return x + str(y)
+
+@rep.register(int)
+def _(x, y):
+    return x * y
+
+# Dispatched eagerly
+rep("1", y=2)  # "12"
+rep("1", y="2")  # "12"
+```
+
+## Pipeable functions
+
+One could register functions as pipeable functions, which means they will work like a verb when a data is piping in. If dispatchable, the first argument will be used to dispatch the implementation. The rest of the arguments will be evaluated using the data from the first argument.
+
+```python
+from pipda import register_func
+
+@register_func(cls=int, pipeable=True)
+def rep(x, y):
+    return x + y
+
+1 >> rep(2)  # 3
 ```

--- a/docs/piping.md
+++ b/docs/piping.md
@@ -1,0 +1,107 @@
+# Piping
+
+## How it works to detect piping
+
+```R
+data %>% verb(arg1, ..., key1=kwarg1, ...)
+```
+
+The above is a typical dplyr/tidyr data piping syntax.
+
+The counterpart python syntax we expect is:
+
+```python
+data >> verb(arg1, ..., key1=kwarg1, ...)
+```
+
+To implement that, we need to defer the execution of the verb by turning it into a Verb object, which holds all information of the function to be executed later. The Verb object won't be executed until the data is piped in. It all thanks to the executing package to let us determine the ast nodes where the function is called. So that we are able to determine whether the function is called in a piping mode.
+
+If an argument is referring to a column of the data and the column will be involved in the later computation, the it also needs to be deferred. For example, with dplyr in R:
+
+```R
+data %>% mutate(z=a)
+```
+
+is trying add a column named z with the data from column a.
+
+In python, we want to do the same with:
+
+```python
+data >> mutate(z=f.a)
+```
+
+where f.a is a Reference object that carries the column information without fetching the data while python sees it immmediately.
+
+Here the trick is f. Like other packages, we introduced the Symbolic object, which will connect the parts in the argument and make the whole argument an Expression object. This object is holding the execution information, which we could use later when the piping is detected.
+
+## Fallbacks when AST node detection fails
+
+`pipda` detects the AST node for the verb calling. If it is next to a piping
+operator (defaults to `>>`, could be changed by `register_piping()`), then it
+is compiled into a `VerbCall` object, awaiting data to pipe in to evalute. We
+call this the `piping` mode. Otherwise, it is treated a as normal function
+call, where the data should be passed directly. This is the `normal` mode.
+
+However, the AST node is not always available. `pipda` relies on
+[`executing`][1] to detect the node. There are situations AST nodes can not be
+detected. One of the biggest reasons is that the source code is not
+avaiable/compromised at runtime. For example, `pytest`'s assert statement,
+raw python REPL, etc.
+
+We can set up a fallback mode when we fail to determine the AST node.
+
+- `piping`: fallback to `piping` mode if AST node not avaiable
+- `normal`: fallback to `normal` node if AST node not avaiable
+- `piping_warning`: fallback to `piping` mode if AST node not avaiable and given a warning
+- `normal_warning` (default): fallback to `normal` mode if AST node not avaiable and given a warning
+- `raise`: Raise an error
+
+We can also pass one of the above values to `__ast_fallback` when we call the verb.
+
+```python
+@register_verb(int, ast_fallback="normal")
+def add(x, y):
+    return x + y
+
+@register_verb(int, ast_fallback="piping")
+def sub(x, y):
+    return x - y
+
+@register_verb(int)
+def mul(x, y):
+    return x * y
+
+# In an environment AST node cannot be detected
+add(1, 2)  # 3, ok
+1 >> add(2)  # TypeError, argument y missing
+
+2 >> sub(1)  # 1, ok
+sub(2, 1)  # TypeError, argument y missing
+
+mul(1, 2, __ast_fallback="normal")  # 3
+1 >> mul(2, __ast_fallback="piping")  # 3
+
+# Change the fallback
+add.ast_fallback = "piping"
+1 >> add(2)  # 3, ok
+add(1, 2)  # VerbCall object
+```
+
+## Using a different operator for piping
+
+By default, `>>` is used for piping. We can also use other operators, including
+">>", "|", "//", "@", "%", "&" and "^".
+
+```python
+from pipda import register_piping, register_verb
+
+register_piping("|")
+
+@register_verb(int)
+def add(x, y):
+    return x + y
+
+1 | add(2)  # 3
+```
+
+[1]: https://github.com/alexmojaki/executing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,8 @@ nav:
     - 'Home': 'index.md'
     - 'Verbs': 'verbs.md'
     - 'Functions': 'functions.md'
+    - 'Backends': 'backends.md'
+    - 'Piping': 'piping.md'
     - 'Expressions': 'expressions.md'
     - 'Operators': 'operators.md'
     - 'Contexts': 'contexts.md'

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -1,21 +1,15 @@
 from .context import Context, ContextBase
 from .expression import Expression, register_expr_array_func
-from .function import (
-    Function,
-    FunctionCall,
-    PipeableFunction,
-    PipeableFunctionCall,
-    register_func,
-)
+from .function import FunctionCall, PipeableFunctionCall, register_func
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem
 from .symbolic import Symbolic
 from .utils import evaluate_expr
-from .verb import (
-    Verb,
-    VerbCall,
-    register_verb,
-)
-from .piping import register_piping
+from .verb import VerbCall, register_verb
+from .piping import register_piping, _patch_default_classes
 
 __version__ = "0.9.0"
+
+
+register_piping(">>")
+_patch_default_classes()

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -4,7 +4,6 @@ from .function import (
     FunctionCall,
     PipeableFunctionCall,
     register_func,
-    register_plain,
 )
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -1,10 +1,6 @@
 from .context import Context, ContextBase
 from .expression import Expression, register_expr_array_func
-from .function import (
-    FunctionCall,
-    PipeableFunctionCall,
-    register_func,
-)
+from .function import FunctionCall, register_func
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem
 from .symbolic import Symbolic

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -1,6 +1,12 @@
 from .context import Context, ContextBase
 from .expression import Expression, register_expr_array_func
-from .function import Function, FunctionCall, register_func
+from .function import (
+    Function,
+    FunctionCall,
+    PipeableFunction,
+    PipeableFunctionCall,
+    register_func,
+)
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem
 from .symbolic import Symbolic

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -1,6 +1,11 @@
 from .context import Context, ContextBase
 from .expression import Expression, register_expr_array_func
-from .function import FunctionCall, PipeableFunctionCall, register_func
+from .function import (
+    FunctionCall,
+    PipeableFunctionCall,
+    register_func,
+    register_plain,
+)
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem
 from .symbolic import Symbolic
@@ -9,7 +14,6 @@ from .verb import VerbCall, register_verb
 from .piping import register_piping, _patch_default_classes
 
 __version__ = "0.9.0"
-
 
 register_piping(">>")
 _patch_default_classes()

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -8,7 +8,7 @@ from .utils import evaluate_expr
 from .verb import VerbCall, register_verb
 from .piping import register_piping, _patch_default_classes
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 register_piping(">>")
 _patch_default_classes()

--- a/pipda/expression.py
+++ b/pipda/expression.py
@@ -203,6 +203,7 @@ class Expression(ABC):
         self,
         data: Any,
         context: ContextBase = None,
+        backend: str = None,
     ) -> Any:
         """Evaluate the expression using given data"""
 

--- a/pipda/expression.py
+++ b/pipda/expression.py
@@ -70,7 +70,7 @@ class Expression(ABC):
         if method != "__call__":
             ufunc = getattr(ufunc, method)
 
-        fun = Function(ufunc, None, {})
+        fun = Function(ufunc)
         return FunctionCall(fun, *inputs, **kwargs)
 
     def __array_ufunc__(

--- a/pipda/expression.py
+++ b/pipda/expression.py
@@ -190,7 +190,7 @@ class Expression(ABC):
         """
         raise TypeError(
             "An Expression object is possible to be iterable only after "
-            "it's evaluate. Do you forget to evalute it or you call it in an "
+            "it's evaluated. Do you forget to evalute it or you call it in an "
             "unregistered function?"
         )
 

--- a/pipda/expression.py
+++ b/pipda/expression.py
@@ -203,7 +203,6 @@ class Expression(ABC):
         self,
         data: Any,
         context: ContextBase = None,
-        backend: str = None,
     ) -> Any:
         """Evaluate the expression using given data"""
 

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -199,7 +199,9 @@ def register_func(
         dispatchable = pipeable = False
 
     def _backend_generic(*args, **kwargs):  # pyright: ignore
-        raise NotImplementedError("Not implemented by the given backend.")
+        raise NotImplementedError(
+            f"`{wrapper.__name__}` is not implemented by the given backend."
+        )
 
     if not isinstance(cls, (list, tuple, set)) and cls is not TypeHolder:
         cls = (cls,)  # type: ignore

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Type
 from types import MappingProxyType
 from functools import singledispatch, update_wrapper
@@ -191,13 +192,15 @@ def register_func(
         raise NotImplementedError("Not implemented by the given backend.")
 
     if dispatchable:
-        registry: Dict[str, Callable] = {
-            DEFAULT_BACKEND: singledispatch(
-                func if cls is TypeHolder else _backend_generic
-            )
-        }
+        registry = OrderedDict(
+            {
+                DEFAULT_BACKEND: singledispatch(
+                    func if cls is TypeHolder else _backend_generic
+                )
+            }
+        )
     else:
-        registry: Dict[str, Callable] = {DEFAULT_BACKEND: func}
+        registry = OrderedDict({DEFAULT_BACKEND: func})  # type: ignore
     # backend => implementation
     favorables: Dict[str, Callable] = {}
 

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -318,7 +318,11 @@ def register_func(
             if backend not in registry:
                 registry[backend] = singledispatch(_backend_generic)
 
-            registry[backend].register(cl, fun)
+            if isinstance(cl, (tuple, list, set)):
+                for c in cl:
+                    registry[backend].register(c, fun)
+            else:
+                registry[backend].register(cl, fun)
 
         if favored:
             favorables[backend] = fun

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -187,6 +187,9 @@ def register_func(
     def _backend_generic(*args, **kwargs):  # pyright: ignore
         raise NotImplementedError("Not implemented by the given backend.")
 
+    if not isinstance(cls, (list, tuple, set)) and cls is not TypeHolder:
+        cls = (cls, )  # type: ignore
+
     if dispatchable:
         registry = OrderedDict(
             {

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -81,9 +81,9 @@ class FunctionCall(Expression):
                 for key, val in kwargs.items()
             }
         else:
-            args = [  # type: ignore
+            args = tuple(
                 evaluate_expr(arg, data, context) for arg in args
-            ]
+            )
             kwargs = {
                 key: evaluate_expr(val, data, context)
                 for key, val in kwargs.items()

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -294,7 +294,14 @@ def register_func(
 
         return impls[0][1]
 
-    def register(cl=None, *, backend=DEFAULT_BACKEND, favored=False, fun=None):
+    def register(
+        cl=None,
+        *,
+        backend=DEFAULT_BACKEND,
+        favored=False,
+        overwrite_doc=False,
+        fun=None,
+    ):
         """generic_func.register(cl, backend, fun, favored) -> fun
 
         Args:
@@ -312,6 +319,7 @@ def register_func(
                 cl,
                 backend=backend,
                 favored=favored,
+                overwrite_doc=overwrite_doc,
                 fun=fn,
             )
 
@@ -329,6 +337,8 @@ def register_func(
 
         if favored:
             favorables[backend] = fun
+        if overwrite_doc:
+            wrapper.__doc__ = fun.__doc__
         return fun
 
     def wrapper(*args, **kwargs):

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -222,13 +222,15 @@ def register_func(
             The implementation function
         """
         if not clses:
-            clses = (object,)
+            clses = (type(None),)
 
         if backend is not None:
             try:
                 reg = registry[backend]
             except KeyError:
-                raise NotImplementedError(f"No such backend `{backend}`.")
+                raise NotImplementedError(
+                    f"No implementations found for backend `{backend}`."
+                )
 
             if not dispatchable:
                 return reg

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -126,7 +126,6 @@ def register_func(
     dispatchable: bool = False,
     pipeable: bool = False,
     ast_fallback: str = "normal_warning",
-    ast_depth: int = 0,
 ) -> Callable:
     """Register a function
 
@@ -163,8 +162,6 @@ def register_func(
             piping_warning - Suppose piping call, but show a warning
             normal_warning - Suppose normal call, but show a warning
             raise - Raise an error
-        ast_depth: Whether this func is wrapped by other wrappers, if so,
-            the depth should be provided to make the AST node detection
 
     Returns:
         The registered func or a decorator to register a func
@@ -181,7 +178,6 @@ def register_func(
             dispatchable=dispatchable,
             pipeable=pipeable,
             ast_fallback=ast_fallback,
-            ast_depth=ast_depth,
         )
 
     if plain:
@@ -336,7 +332,7 @@ def register_func(
         if pipeable:
             ast_fb = kwargs.pop("__ast_fallback", ast_fallback)
 
-            if is_piping(wrapper.__name__, ast_fb, ast_depth):
+            if is_piping(wrapper.__name__, ast_fb):
                 return PipeableFunctionCall(wrapper, *args, **kwargs)
 
         # Not pipeable

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, Callable, List, TYPE_CHECKING, Sequence, Set, Type
+from typing import Any, Callable, List, TYPE_CHECKING, Sequence, Type
 from functools import singledispatch, update_wrapper
 
 from .utils import evaluate_expr, has_expr, update_user_wrapper, is_piping
@@ -147,7 +147,7 @@ class Function(Registered):
         doc: str = None,
         module: str = None,
         signature: inspect.Signature = None,
-        dispatchable: str | Set[str] = None,
+        dispatchable: bool = False,
     ) -> None:
         self._signature = signature
         self.dispatchable = dispatchable
@@ -221,7 +221,7 @@ class PipeableFunction(Function):
         module: str = None,
         signature: inspect.Signature = None,
         ast_fallback: str = "normal_warning",
-        dispatchable: str | Set[str] = None,
+        dispatchable: bool = False,
     ) -> None:
         super().__init__(
             func,
@@ -254,7 +254,7 @@ def register_func(
     signature: inspect.Signature = None,
     pipeable: bool = False,
     ast_fallback: str = "normal_warning",
-    dispatchable: str | Set[str] = None,
+    dispatchable: bool = False,
     funclass: Type[Function] = None,
 ) -> Function | Callable:
     """Register a function to be used as a verb argument so that they don't
@@ -270,9 +270,8 @@ def register_func(
             or when it's not available from `func`
         pipeable: Whether the function is pipeable
             If pipeable, `[1, 2, 3] >> sum()` is supported
-        dispatchable: Whether the function is dispatchable, if so, it should
-            be the name/names of the arguments that are used to detect the
-            dispatched type.
+        dispatchable: Whether the function is dispatchable. The type of
+            any argument will be used to dispatch the function.
 
     Returns:
         A registered `Function` object, or a decorator if `func` is not given

--- a/pipda/function.py
+++ b/pipda/function.py
@@ -1,18 +1,23 @@
-"""Provide definition for functions that used as verb arguments"""
 from __future__ import annotations
 
-import inspect
-from abc import ABC, abstractmethod
-from typing import Any, Callable, List, TYPE_CHECKING, Sequence, Type
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, List, Type
+from types import MappingProxyType
 from functools import singledispatch, update_wrapper
 
-from .utils import evaluate_expr, has_expr, update_user_wrapper, is_piping
+from .utils import (
+    MultiImplementationsWarning,
+    TypeHolder,
+    evaluate_expr,
+    update_user_wrapper,
+    has_expr,
+    is_piping,
+)
 from .expression import Expression
+from .piping import PipeableCall
 
 if TYPE_CHECKING:
-    from inspect import BoundArguments
     from .context import ContextType
-    from .verb import Verb
 
 
 class FunctionCall(Expression):
@@ -27,20 +32,26 @@ class FunctionCall(Expression):
 
     def __init__(
         self,
-        func: Function | Verb | Expression,
+        func: Callable | Expression,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         self._pipda_func = func
         self._pipda_args = args
         self._pipda_kwargs = kwargs
+        self._pipda_backend = kwargs.pop("__backend", None)
 
     def __str__(self) -> str:
         """Representation of the function call"""
         strargs: List[str] = []
-        funname = str(self._pipda_func)
+        if isinstance(self._pipda_func, Expression):
+            funname = str(self._pipda_func)
+        else:
+            funname = self._pipda_func.__name__
+
         if self._pipda_args:
             strargs.extend((str(arg) for arg in self._pipda_args))
+
         if self._pipda_kwargs:
             strargs.extend(
                 f"{key}={val}" for key, val in self._pipda_kwargs.items()
@@ -60,255 +71,222 @@ class FunctionCall(Expression):
             # f.a(1)
             func = evaluate_expr(func, data, context)
 
-        if not isinstance(func, Function):
-            return func(*args, **kwargs)
+        functype = getattr(func, "_pipda_functype", None)
+        if functype == "func":
+            func = func._pipda_origfunc
+        elif functype == "dispatchable_func":
+            func.dispatch(
+                *(arg.__class__ for arg in args),
+                backend=self._pipda_backend,
+            )
 
-        if not args and not kwargs:
-            return func.func()
-
-        if func.dispatchable:
-            for t, fun in reversed(func.registry.items()):
-                if t is object:
-                    continue
-                if (
-                    any(isinstance(arg, t) for arg in args)
-                    or any(isinstance(val, t) for val in kwargs.values())
-                ):
-                    return fun(*args, **kwargs)
-
-        return func.func(*args, **kwargs)
+        return func(*args, **kwargs)
 
 
-class PipeableFunctionCall(FunctionCall):
-
+class PipeableFunctionCall(FunctionCall, PipeableCall):
     def _pipda_eval(self, data: Any, context: ContextType = None) -> Any:
+        """Evaluate the function call with the piped data
+
+        Note that the piped data is the first argument, not the data from
+        a verb that used to evaluate other expression arguments.
+        """
         func = self._pipda_func
-        args = [evaluate_expr(arg, data, context) for arg in self._pipda_args]
-        kwargs = {
-            key: evaluate_expr(val, data, context)
-            for key, val in self._pipda_kwargs.items()
-        }
+        args = (data, *self._pipda_args)
+        if has_expr(args) or has_expr(self._pipda_kwargs):
+            return FunctionCall(
+                func,
+                *args,
+                **self._pipda_kwargs,
+                __backend=self._pipda_backend,
+            )
 
-        if not isinstance(func, Function):
-            return func(data, *args, **kwargs)
+        functype = getattr(func, "_pipda_functype", None)
+        if functype == "func":
+            func = func._pipda_origfunc  # type: ignore
+        elif functype == "dispatchable_func":
+            func.dispatch(  # type: ignore
+                *(arg.__class__ for arg in args),
+                backend=self._pipda_backend,
+            )
 
-        if func.dispatchable:
-            for t, fun in reversed(func.registry.items()):
-                if t is object:
-                    continue
-                if (
-                    isinstance(data, t)
-                    or any(isinstance(arg, t) for arg in args)
-                    or any(isinstance(val, t) for val in kwargs.values())
-                ):
-                    return fun(data, *args, **kwargs)
-
-        return func.func(data, *args, **kwargs)
-
-
-class Registered(ABC):
-    """Base function for registered function/verb"""
-
-    def __str__(self):
-        """Used to stringify the whole expression"""
-        return self.func.__name__
-
-    @property
-    def signature(self):
-        # cached property returns None for numpy.vectorize() object
-        if not self._signature:
-            self._signature = inspect.signature(self.func)
-        return self._signature
-
-    def bind_arguments(self, *args, **kwargs: Any) -> BoundArguments:
-        boundargs = self.signature.bind(*args, **kwargs)
-        boundargs.apply_defaults()
-        return boundargs
-
-    @abstractmethod
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Call a registered function/verb"""
-
-
-class Function(Registered):
-    """Registered function
-
-    Args:
-        func: The original function
-        context: The context
-        extra_context: The extra context for keyword arguments
-    """
-
-    def __init__(
-        self,
-        func: Callable,
-        name: str = None,
-        qualname: str = None,
-        doc: str = None,
-        module: str = None,
-        signature: inspect.Signature = None,
-        dispatchable: bool = False,
-    ) -> None:
-        self._signature = signature
-        self.dispatchable = dispatchable
-
-        update_wrapper(self, func)
-        update_user_wrapper(
-            self,
-            name=name,
-            qualname=qualname,
-            doc=doc,
-            module=module,
-        )
-
-        if self.dispatchable:
-
-            @singledispatch
-            def _func(*args, **kwargs):
-                return func(*args, **kwargs)
-
-            self.func = _func  # type: ignore
-            self.registry = _func.registry
-            self.dispatch = _func.dispatch
-        else:
-            self.func = func  # type: ignore
-
-    def register(
-        self,
-        types: Type | Sequence[Type],
-    ) -> Callable[[Callable], Function]:
-        """Register a function for a type"""
-        if not self.dispatchable:
-            raise ValueError("Function is not dispatchable")
-
-        if not isinstance(types, (list, tuple, set)):
-            types = [types]  # type: ignore [list-item]
-
-        def _register(func):
-            for t in types:
-                self.func.register(t, func)
-            return self
-
-        return _register
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Call a registered function"""
-        if not args and not kwargs:
-            return self.func()
-
-        if not has_expr(args) and not has_expr(kwargs):
-            if self.dispatchable:
-                for t, fun in reversed(self.registry.items()):
-                    if t is object:
-                        continue
-                    if (
-                        any(isinstance(arg, t) for arg in args)
-                        or any(isinstance(val, t) for val in kwargs.values())
-                    ):
-                        return fun(*args, **kwargs)
-            return self.func(*args, **kwargs)
-
-        return FunctionCall(self, *args, **kwargs)
-
-
-class PipeableFunction(Function):
-    def __init__(
-        self,
-        func: Callable,
-        name: str = None,
-        qualname: str = None,
-        doc: str = None,
-        module: str = None,
-        signature: inspect.Signature = None,
-        ast_fallback: str = "normal_warning",
-        dispatchable: bool = False,
-    ) -> None:
-        super().__init__(
-            func,
-            name,
-            qualname,
-            doc,
-            module,
-            signature,
-            dispatchable,
-        )
-        self.ast_fallback = ast_fallback
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        """Call a registered pipeable function"""
-        ast_fallback = kwargs.pop("__ast_fallback", self.ast_fallback)
-
-        if is_piping(self.func.__name__, ast_fallback):
-            return PipeableFunctionCall(self, *args, **kwargs)
-
-        return super().__call__(*args, **kwargs)
+        return func(*args, **self._pipda_kwargs)
 
 
 def register_func(
     func: Callable = None,
+    cls: Type = TypeHolder,
     *,
     name: str = None,
     qualname: str = None,
     doc: str = None,
     module: str = None,
-    signature: inspect.Signature = None,
+    dispatchable: bool = False,
     pipeable: bool = False,
     ast_fallback: str = "normal_warning",
-    dispatchable: bool = False,
-    funclass: Type[Function] = None,
-) -> Function | Callable:
-    """Register a function to be used as a verb argument so that they don't
-    get evaluated immediately
+    ast_depth: int = 0,
+) -> Callable:
+    """Register a function
+
+    A function, unlike a verb, is a function that doesn't evaluate its
+    arguments by the first argument, which is the data, it depends on the
+    data from a verb to evaluate the arguments if they are Expression objects.
+
+    A function can also be defined as pipeable, so that the first argument
+    can be piped in later.
+
+    A function can also be defined as dispatchable. The types of any positional
+    arguments are used to dispatch the implementation.
 
     Args:
-        func: The original function
+        func: The generic function.
+            If `None` (not provided), this function will return a decorator.
+        cls: The default type to register for _default backend
+            if TypeHolder, it is a generic function, and not counted as a
+            real implementation.
         name: and
         qualname: and
         doc: and
-        module: and
-        signature: The meta information about the function to overwrite `func`'s
+        module: The meta information about the function to overwrite `func`'s
             or when it's not available from `func`
-        pipeable: Whether the function is pipeable
-            If pipeable, `[1, 2, 3] >> sum()` is supported
-        dispatchable: Whether the function is dispatchable. The type of
-            any argument will be used to dispatch the function.
+        ast_fallback: What's the supposed way to call the func when
+            AST node detection fails.
+            piping - Suppose this func is called like `data >> func(...)`
+            normal - Suppose this func is called like `func(data, ...)`
+            piping_warning - Suppose piping call, but show a warning
+            normal_warning - Suppose normal call, but show a warning
+            raise - Raise an error
+        ast_depth: Whether this func is wrapped by other wrappers, if so,
+            the depth should be provided to make the AST node detection
 
     Returns:
-        A registered `Function` object, or a decorator if `func` is not given
+        The registered func or a decorator to register a func
     """
     if func is None:
         return lambda fun: register_func(
             fun,
+            cls=cls,
             name=name,
             qualname=qualname,
             doc=doc,
             module=module,
-            signature=signature,
+            dispatchable=dispatchable,
             pipeable=pipeable,
-            dispatchable=dispatchable,
-            funclass=funclass,
-        )
-
-    if pipeable:
-        funclass = funclass or PipeableFunction
-        return funclass(  # type: ignore
-            func,
-            name=name,
-            qualname=qualname,
-            doc=doc,
-            module=module,
-            signature=signature,
             ast_fallback=ast_fallback,
-            dispatchable=dispatchable,
+            ast_depth=ast_depth,
         )
 
-    funclass = funclass or Function
-    return Function(
-        func,
+    def _backend_generic(*args, **kwargs):  # pyright: ignore
+        raise NotImplementedError("Not implemented by the given backend.")
+
+    registry = {
+        "_default": singledispatch(
+            func if cls is TypeHolder else _backend_generic
+        )
+    }
+
+    def dispatch(*clses, backend=None):
+        """generic_func.dispatch(*clses, backend) -> <function impl>
+
+        Runs the dispatch algorithm to return the best available implementation
+        for the given *cls* registered on *generic_func* of given *backend*.
+
+        If backend is not provided, we will look for the implementation of
+        the backends in reverse order.
+
+        The first cls can be dispatched is used.
+        """
+        if not clses:
+            clses = (object,)
+
+        if backend is not None:
+            try:
+                reg = registry[backend]
+            except KeyError:
+                raise NotImplementedError(f"No such backend `{backend}`.")
+
+            for cl in clses:
+                dispatched = reg.dispatch(cl)
+                # Any impl found
+                if dispatched is not _backend_generic:
+                    return dispatched
+            return _backend_generic
+
+        impls = []
+        for backend, reg in reversed(registry.items()):
+            for cl in clses:
+                fun = reg.dispatch(cl)
+                if fun is _backend_generic or (
+                    fun is func and cls is TypeHolder and backend == "_default"
+                ):
+                    continue
+
+                impls.append((backend, fun))
+                break
+
+        if not impls:
+            return func if cls is TypeHolder else _backend_generic
+
+        if len(impls) > 1:
+            warnings.warn(
+                f"Multiple implementations found for `{wrapper.__name__}` "
+                f"by backends: [{', '.join(impl[0] for impl in impls)}], "
+                "register with more specific types, or pass "
+                "`__backend=<backend>` to specify the backend.",
+                MultiImplementationsWarning,
+            )
+
+        return impls[0][1]
+
+    def register(cl, backend="_default", fun=None):
+
+        if fun is None:
+            return lambda fn: register(cl, backend=backend, fun=fn)
+
+        if backend not in registry:
+            registry[backend] = singledispatch(_backend_generic)
+
+        registry[backend].register(cl, fun)
+        return fun
+
+    def wrapper(*args, **kwargs):
+        if pipeable:
+            ast_fb = kwargs.pop("__ast_fallback", ast_fallback)
+
+            if is_piping(wrapper.__name__, ast_fb, ast_depth):
+                return PipeableFunctionCall(wrapper, *args, **kwargs)
+
+        # Not pipeable
+        if has_expr(args) or has_expr(kwargs):
+            return FunctionCall(wrapper, *args, **kwargs)
+
+        # No Expression objects, call directly
+        backend = kwargs.pop("__backend", None)
+
+        if not dispatchable:
+            return func(*args, **kwargs)
+
+        return dispatch(
+            *(arg.__class__ for arg in args),
+            backend=backend,
+        )(*args, **kwargs)
+
+    if dispatchable:
+        if cls is not TypeHolder:
+            register(cls, fun=func)
+        wrapper._pipda_functype = "dispatchable_func"
+        wrapper.registry = MappingProxyType(registry)
+        wrapper.dispatch = dispatch
+        wrapper.register = register
+    else:
+        wrapper._pipda_functype = "func"
+        wrapper._pipda_origfunc = func
+
+    update_wrapper(wrapper, func)
+    update_user_wrapper(
+        wrapper,
         name=name,
         qualname=qualname,
         doc=doc,
         module=module,
-        signature=signature,
-        dispatchable=dispatchable,
     )
+    return wrapper

--- a/pipda/operator.py
+++ b/pipda/operator.py
@@ -43,11 +43,10 @@ class OperatorCall(Expression):
         self,
         data: Any,
         context: ContextType = None,
-        backend: str = None,
     ) -> Any:
         """Evaluate the operator call"""
         operands = (
-            evaluate_expr(arg, data, context, backend)
+            evaluate_expr(arg, data, context)
             for arg in self._pipda_operands
         )
         return self._pipda_op_func(*operands)

--- a/pipda/operator.py
+++ b/pipda/operator.py
@@ -20,7 +20,9 @@ class OperatorCall(Expression):
         operands: The operands of the operator
     """
 
-    def __init__(self, op_func: Callable, op_name: str, *operands: Any) -> None:
+    def __init__(
+        self, op_func: Callable, op_name: str, *operands: Any
+    ) -> None:
         self._pipda_op_func = op_func
         self._pipda_op_name = op_name
         self._pipda_operands = operands
@@ -37,10 +39,15 @@ class OperatorCall(Expression):
 
         return f" {op} ".join(str(operand) for operand in self._pipda_operands)
 
-    def _pipda_eval(self, data: Any, context: ContextType = None) -> Any:
+    def _pipda_eval(
+        self,
+        data: Any,
+        context: ContextType = None,
+        backend: str = None,
+    ) -> Any:
         """Evaluate the operator call"""
         operands = (
-            evaluate_expr(arg, data, context)
+            evaluate_expr(arg, data, context, backend)
             for arg in self._pipda_operands
         )
         return self._pipda_op_func(*operands)
@@ -60,6 +67,7 @@ class Operator:
         >>>     def add(self, x, y):
         >>>         return x * y
     """
+
     def __getattr__(self, name: str) -> Callable:
         if not OPERATORS[name][1]:
             # not a right operator (e.g. radd)
@@ -84,5 +92,6 @@ def register_operator(opclass: Type) -> Type:
         The opclass
     """
     from .expression import Expression
+
     Expression._pipda_operator = opclass()
     return opclass

--- a/pipda/piping.py
+++ b/pipda/piping.py
@@ -171,27 +171,15 @@ def register_piping(op: str) -> None:
         raise ValueError(f"Unsupported piping operator: {op}")
 
     from .verb import VerbCall
-    from .function import PipeableFunctionCall
 
     if PipeableCall.PIPING:
         curr_method = PIPING_OPS[PipeableCall.PIPING][0]
         verb_orig_method = VerbCall.__orig_opmethod__
         setattr(VerbCall, curr_method, verb_orig_method)
-        func_orig_method = PipeableFunctionCall.__orig_opmethod__
-        setattr(PipeableFunctionCall, curr_method, func_orig_method)
         _unpatch_all(PipeableCall.PIPING)
 
     PipeableCall.PIPING = op
     VerbCall.__orig_opmethod__ = getattr(VerbCall, PIPING_OPS[op][0])
     setattr(VerbCall, PIPING_OPS[op][0], VerbCall._pipda_eval)
-    PipeableFunctionCall.__orig_opmethod__ = getattr(
-        PipeableFunctionCall,
-        PIPING_OPS[op][0],
-    )
-    setattr(
-        PipeableFunctionCall,
-        PIPING_OPS[op][0],
-        PipeableFunctionCall._pipda_eval,
-    )
 
     _patch_all(op)

--- a/pipda/reference.py
+++ b/pipda/reference.py
@@ -30,7 +30,6 @@ class Reference(Expression, ABC):
         self,
         data: Any,
         context: ContextType = None,
-        backend: str = None,
     ) -> Any:
         """Evaluate the reference according to the context"""
         if context is None:
@@ -53,7 +52,6 @@ class ReferenceAttr(Reference):
         self,
         data: Any,
         context: ContextType = None,
-        backend: str = None,
     ) -> Any:
         """Evaluate the attribute references"""
         if isinstance(context, Enum):
@@ -61,8 +59,8 @@ class ReferenceAttr(Reference):
 
         # if we don't have a context here, assuming that
         # we are calling `f.a.b(1)`, instead of evaluation
-        super()._pipda_eval(data, context, backend)
-        parent = evaluate_expr(self._pipda_parent, data, context, backend)
+        super()._pipda_eval(data, context)
+        parent = evaluate_expr(self._pipda_parent, data, context)
 
         return context.getattr(  # type: ignore
             parent,
@@ -95,19 +93,17 @@ class ReferenceItem(Reference):
         self,
         data: Any,
         context: ContextType = None,
-        backend: str = None,
     ) -> Any:
         """Evaluate the subscript references"""
         if isinstance(context, Enum):
             context = context.value
 
-        super()._pipda_eval(data, context, backend)
-        parent = evaluate_expr(self._pipda_parent, data, context, backend)
+        super()._pipda_eval(data, context)
+        parent = evaluate_expr(self._pipda_parent, data, context)
         ref = evaluate_expr(
             self._pipda_ref,
             data,
             context.ref,  # type: ignore
-            backend,
         )
 
         return context.getitem(parent, ref, self._pipda_level)  # type: ignore

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -12,6 +12,7 @@ class Symbolic(Expression):
     """The symbolic class, works as a proxy to represent the data
     In most cases it is used to construct the Reference objects.
     """
+
     _pipda_level = 0
     _pipda_instance = None
 
@@ -26,6 +27,11 @@ class Symbolic(Expression):
     def __str__(self) -> str:
         return ""
 
-    def _pipda_eval(self, data: Any, context: ContextType = None) -> Any:
+    def _pipda_eval(
+        self,
+        data: Any,
+        context: ContextType = None,
+        backend: str = None,
+    ) -> Any:
         """When evaluated, this should just return the data directly"""
         return data

--- a/pipda/symbolic.py
+++ b/pipda/symbolic.py
@@ -31,7 +31,6 @@ class Symbolic(Expression):
         self,
         data: Any,
         context: ContextType = None,
-        backend: str = None,
     ) -> Any:
         """When evaluated, this should just return the data directly"""
         return data

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -46,11 +46,7 @@ def update_user_wrapper(
         x.__module__ = module
 
 
-def is_piping(
-    pipeable: str,
-    fallback: str,
-    depth: int,
-) -> bool:
+def is_piping(pipeable: str, fallback: str) -> bool:
     """Check if the pipeable is called with piping.
 
     Example:
@@ -72,7 +68,8 @@ def is_piping(
     from executing import Source
     from .piping import PIPING_OPS, PipeableCall
 
-    frame = sys._getframe(depth + 2)
+    # Caching?
+    frame = sys._getframe(2)
     node = Source.executing(frame).node
 
     if not node:
@@ -107,12 +104,9 @@ def is_piping(
         return False
 
     return (
-        (
-            (isinstance(parent, ast.BinOp) and parent.right is node)
-            or (isinstance(parent, ast.AugAssign) and parent.value is node)
-        )
-        and isinstance(parent.op, PIPING_OPS[PipeableCall.PIPING][1])
-    )
+        (isinstance(parent, ast.BinOp) and parent.right is node)
+        or (isinstance(parent, ast.AugAssign) and parent.value is node)
+    ) and isinstance(parent.op, PIPING_OPS[PipeableCall.PIPING][1])
 
 
 def evaluate_expr(expr: Any, data: Any, context: ContextType) -> Any:

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -113,7 +113,6 @@ def evaluate_expr(
     expr: Any,
     data: Any,
     context: ContextType,
-    backend: str = None,
 ) -> Any:
     """Evaluate a mixed expression"""
     if isinstance(context, Enum):
@@ -122,25 +121,25 @@ def evaluate_expr(
     if hasattr(expr.__class__, "_pipda_eval"):
         # Not only for Expression objects, but also
         # allow customized classes
-        return expr._pipda_eval(data, context, backend)
+        return expr._pipda_eval(data, context)
 
     if isinstance(expr, (tuple, list, set)):
         # In case it's subclass
         return expr.__class__(
-            (evaluate_expr(elem, data, context, backend) for elem in expr)
+            (evaluate_expr(elem, data, context) for elem in expr)
         )
 
     if isinstance(expr, slice):
         return slice(
-            evaluate_expr(expr.start, data, context, backend),
-            evaluate_expr(expr.stop, data, context, backend),
-            evaluate_expr(expr.step, data, context, backend),
+            evaluate_expr(expr.start, data, context),
+            evaluate_expr(expr.stop, data, context),
+            evaluate_expr(expr.step, data, context),
         )
 
     if isinstance(expr, dict):
         return expr.__class__(
             {
-                key: evaluate_expr(val, data, context, backend)
+                key: evaluate_expr(val, data, context)
                 for key, val in expr.items()
             }
         )

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -33,15 +33,15 @@ def update_user_wrapper(
         x.__module__ = module
 
 
-def is_piping_verbcall(verb: str, fallback: str) -> bool:
-    """Check if the verb is called with piping.
+def is_piping(pipeable: str, fallback: str) -> bool:
+    """Check if the pipeable is called with piping.
 
     Example:
         >>> data >> verb(...)
         >>> data >>= verb(...)
 
     Args:
-        verb: The name of the verb, used in warning or exception messaging
+        pipeable: The name of the verb, used in warning or exception messaging
         fallback: What if the AST node fails to retrieve?
             piping - Suppose this verb is called like `data >> verb(...)`
             normal - Suppose this verb is called like `verb(data, ...)`
@@ -67,21 +67,21 @@ def is_piping_verbcall(verb: str, fallback: str) -> bool:
             return True
         if fallback == "normal_warning":
             warnings.warn(
-                f"Failed to detect AST node calling `{verb}`, "
+                f"Failed to detect AST node calling `{pipeable}`, "
                 "assuming a normal call.",
                 VerbCallingCheckWarning,
             )
             return False
         if fallback == "piping_warning":
             warnings.warn(
-                f"Failed to detect AST node calling `{verb}`, "
+                f"Failed to detect AST node calling `{pipeable}`, "
                 "assuming a piping call.",
                 VerbCallingCheckWarning,
             )
             return True
 
         raise VerbCallingCheckError(
-            f"Failed to detect AST node calling `{verb}` "
+            f"Failed to detect AST node calling `{pipeable}` "
             "without a fallback solution."
         )
 

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -10,6 +10,8 @@ import warnings
 
 from .context import ContextType
 
+DEFAULT_BACKEND = "_default"
+
 
 class PipeableCallCheckWarning(Warning):
     """Warns when checking verb is called normally or using piping"""

--- a/pipda/utils.py
+++ b/pipda/utils.py
@@ -109,7 +109,12 @@ def is_piping(pipeable: str, fallback: str) -> bool:
     ) and isinstance(parent.op, PIPING_OPS[PipeableCall.PIPING][1])
 
 
-def evaluate_expr(expr: Any, data: Any, context: ContextType) -> Any:
+def evaluate_expr(
+    expr: Any,
+    data: Any,
+    context: ContextType,
+    backend: str = None,
+) -> Any:
     """Evaluate a mixed expression"""
     if isinstance(context, Enum):
         context = context.value
@@ -117,25 +122,25 @@ def evaluate_expr(expr: Any, data: Any, context: ContextType) -> Any:
     if hasattr(expr.__class__, "_pipda_eval"):
         # Not only for Expression objects, but also
         # allow customized classes
-        return expr._pipda_eval(data, context)
+        return expr._pipda_eval(data, context, backend)
 
     if isinstance(expr, (tuple, list, set)):
         # In case it's subclass
         return expr.__class__(
-            (evaluate_expr(elem, data, context) for elem in expr)
+            (evaluate_expr(elem, data, context, backend) for elem in expr)
         )
 
     if isinstance(expr, slice):
         return slice(
-            evaluate_expr(expr.start, data, context),
-            evaluate_expr(expr.stop, data, context),
-            evaluate_expr(expr.step, data, context),
+            evaluate_expr(expr.start, data, context, backend),
+            evaluate_expr(expr.stop, data, context, backend),
+            evaluate_expr(expr.step, data, context, backend),
         )
 
     if isinstance(expr, dict):
         return expr.__class__(
             {
-                key: evaluate_expr(val, data, context)
+                key: evaluate_expr(val, data, context, backend)
                 for key, val in expr.items()
             }
         )

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -17,7 +17,7 @@ from functools import singledispatch, update_wrapper
 from .utils import (
     has_expr,
     evaluate_expr,
-    is_piping_verbcall,
+    is_piping,
     update_user_wrapper,
 )
 from .context import ContextPending
@@ -210,7 +210,7 @@ class Verb(Registered):
 
         ast_fallback = kwargs.pop("__ast_fallback", self.ast_fallback)
 
-        if is_piping_verbcall(self.func.__name__, ast_fallback):
+        if is_piping(self.func.__name__, ast_fallback):
             # data >> verb(...)
             return VerbCall(self, *args, **kwargs)
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -179,14 +179,14 @@ class Verb(Registered):
         if not isinstance(types, (list, tuple, set)):
             types = [types]  # type: ignore [list-item]
 
-        def decor(fun: Callable) -> Verb:
+        def _register(fun: Callable) -> Verb:
             self.contexts[fun] = context
             self.extra_contexts[fun] = extra_contexts or {}
             for t in types:
                 self.func.register(t, fun)
             return self
 
-        return decor
+        return _register
 
     def registered(self, cls: Type) -> bool:
         """Check if a type is registered"""

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -1,5 +1,6 @@
 import warnings
 from enum import Enum
+from collections import OrderedDict
 from types import MappingProxyType
 from typing import Any, Callable, Dict, List, Type
 from functools import singledispatch, update_wrapper
@@ -143,11 +144,13 @@ def register_verb(
     def _backend_generic(*args, **kwargs):
         raise NotImplementedError("Not implemented by the given backend.")
 
-    registry = {
-        DEFAULT_BACKEND: singledispatch(
-            func if cls is TypeHolder else _backend_generic
-        )
-    }
+    registry = OrderedDict(
+        {
+            DEFAULT_BACKEND: singledispatch(
+                func if cls is TypeHolder else _backend_generic
+            )
+        }
+    )
     # backend => implementation
     favorables: Dict[str, Callable] = {}
     # # cannot create weak reference to 'numpy.ufunc' object
@@ -264,6 +267,7 @@ def register_verb(
     wrapper.dispatch = dispatch
     wrapper.register = register
     wrapper.favorables = MappingProxyType(favorables)
+    wrapper.dependent = dependent
     wrapper._pipda_functype = "verb"
     update_wrapper(wrapper, func)
     update_user_wrapper(

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -228,7 +228,12 @@ def register_verb(
         if backend not in registry:
             registry[backend] = singledispatch(_backend_generic)
 
-        registry[backend].register(cl, fun)
+        if isinstance(cl, (tuple, list, set)):
+            for c in cl:
+                registry[backend].register(c, fun)
+        else:
+            registry[backend].register(cl, fun)
+
         if context is not None:
             contexts[fun] = context
         if favored:

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -219,6 +219,7 @@ def register_verb(
         backend=DEFAULT_BACKEND,
         context=None,
         favored=False,
+        overwrite_doc=False,
         fun=None,
     ):
         if fun is None:
@@ -227,6 +228,7 @@ def register_verb(
                 backend=backend,
                 context=context,
                 favored=favored,
+                overwrite_doc=overwrite_doc,
                 fun=fn,
             )
 
@@ -243,6 +245,8 @@ def register_verb(
             contexts[fun] = context
         if favored:
             favorables[backend] = fun
+        if overwrite_doc:
+            wrapper.__doc__ = fun.__doc__
         return fun
 
     def wrapper(*args, **kwargs):

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -235,7 +235,7 @@ def register_verb(
     module: str = None,
     signature: Signature = None,
     dep: bool = False,
-    ast_fallback: str = "normal_warning",
+    ast_fallback: str = "piping_warning",
     func: Callable = None,
 ) -> Callable[[Callable], Verb] | Verb:
     """Register a verb

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -83,7 +83,6 @@ def register_verb(
     module: str = None,
     dependent: bool = False,
     ast_fallback: str = "piping_warning",
-    ast_depth: int = 0,
 ) -> Callable:
     """Register a verb
 
@@ -121,8 +120,6 @@ def register_verb(
             piping_warning - Suppose piping call, but show a warning
             normal_warning - Suppose normal call, but show a warning
             raise - Raise an error
-        ast_depth: Whether this verb is wrapped by other wrappers, if so,
-            the depth should be provided to make the AST node detection
 
     Returns:
         The registered verb or a decorator to register a verb
@@ -138,7 +135,6 @@ def register_verb(
             module=module,
             dependent=dependent,
             ast_fallback=ast_fallback,
-            ast_depth=ast_depth,
         )
 
     def _backend_generic(*args, **kwargs):
@@ -244,7 +240,7 @@ def register_verb(
             return VerbCall(wrapper, *args, **kwargs)
 
         ast_fb = kwargs.pop("__ast_fallback", ast_fallback)
-        if is_piping(wrapper.__name__, ast_fb, ast_depth):
+        if is_piping(wrapper.__name__, ast_fb):
             return VerbCall(wrapper, *args, **kwargs)
 
         if not args:

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import warnings
 from enum import Enum
 from collections import OrderedDict
 from types import MappingProxyType
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable, Dict, List, Type, Sequence
 from functools import singledispatch, update_wrapper
 
 from .utils import (
@@ -73,7 +75,7 @@ class VerbCall(PipeableCall):
 
 
 def register_verb(
-    cls: Type = TypeHolder,
+    cls: Type | Sequence[Type] = TypeHolder,
     *,
     func: Callable = None,
     context: ContextType = None,
@@ -139,6 +141,9 @@ def register_verb(
 
     def _backend_generic(*args, **kwargs):
         raise NotImplementedError("Not implemented by the given backend.")
+
+    if not isinstance(cls, (list, tuple, set)) and cls is not TypeHolder:
+        cls = (cls, )  # type: ignore
 
     registry = OrderedDict(
         {
@@ -261,7 +266,7 @@ def register_verb(
 
         return VerbCall(wrapper, *args, **kwargs)._pipda_eval(data)
 
-    if cls:
+    if cls is not TypeHolder:
         register(cls, context=context, fun=func)
 
     wrapper.registry = MappingProxyType(registry)

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -235,6 +235,7 @@ def register_verb(
     module: str = None,
     signature: Signature = None,
     dep: bool = False,
+    verbclass: Type[Verb] = Verb,
     ast_fallback: str = "piping_warning",
     func: Callable = None,
 ) -> Callable[[Callable], Verb] | Verb:
@@ -299,7 +300,7 @@ def register_verb(
     if types is not None and not isinstance(types, (list, tuple, set)):
         types = [types]  # type: ignore [list-item]
 
-    return Verb(
+    return verbclass(
         func,
         types=types,
         context=context,

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -172,7 +172,9 @@ def register_verb(
             try:
                 reg = registry[backend]
             except KeyError:
-                raise NotImplementedError(f"No such backend `{backend}`.")
+                raise NotImplementedError(
+                    f"No implementations found for backend `{backend}`."
+                )
             dispatched = reg.dispatch(cl)
             return dispatched, contexts.get(dispatched, context)
 

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -181,6 +181,7 @@ def register_verb(
                 reg = registry[backend]
             except KeyError:
                 raise NotImplementedError(
+                    f"[{wrapper.__name__}] "
                     f"No implementations found for backend `{backend}`."
                 )
             return reg.dispatch(cl)

--- a/pipda/verb.py
+++ b/pipda/verb.py
@@ -140,7 +140,9 @@ def register_verb(
         )
 
     def _backend_generic(*args, **kwargs):
-        raise NotImplementedError("Not implemented by the given backend.")
+        raise NotImplementedError(
+            f"`{wrapper.__name__}` is not implemented by the given backend."
+        )
 
     if not isinstance(cls, (list, tuple, set)) and cls is not TypeHolder:
         cls = (cls, )  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7.1"
-executing = "^1.1.1"
+executing = "^1.1, !=1.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.9.0"
+version = "0.10.0"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]
@@ -32,8 +32,8 @@ addopts = "-vv -W error::UserWarning -p no:asyncio --cov-config=.coveragerc --co
 console_output_style = "progress"
 junit_family = "xunit1"
 filterwarnings = [
-    # "error",
-    "ignore::DeprecationWarning",
+    "error",
+    # "ignore::DeprecationWarning",
 ]
 
 [tool.black]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,12 @@
 import pytest
 
-from pipda.context import *
+from pipda.context import (
+    Context,
+    ContextSelect,
+    ContextEval,
+    ContextPending,
+    ContextError,
+)
 from pipda import evaluate_expr, Symbolic
 
 
@@ -12,8 +18,8 @@ def test_context_select():
 
 def test_context_eval():
     ce = ContextEval()
-    l = []
-    assert ce.getattr(l, "__len__", 1) == l.__len__
+    lst = []
+    assert ce.getattr(lst, "__len__", 1) == lst.__len__
     assert ce.getitem([1, 2], 0, 1) == 1
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -28,10 +28,16 @@ def test_user_context():
         def getitem(self, parent, ref, level):
             return parent[ref] * 2
 
+        def getattr(self, parent, ref, level):
+            return level
+
     ce = MyContext()
     f = Symbolic()
     out = evaluate_expr(f[1], [1, 2], ce)
     assert out == 4 and isinstance(out, int)
+
+    out = evaluate_expr(f.a.b.c, 1, ce)
+    assert out == 3 and isinstance(out, int)
 
 
 def test_context_pending():

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from pipda.context import Context
 from pipda.expression import Expression, register_expr_array_func
-from pipda.function import FunctionCall, Function
+from pipda.function import FunctionCall
 from pipda.reference import ReferenceAttr, ReferenceItem
 from pipda.symbolic import Symbolic
 from pipda.verb import register_verb
@@ -154,8 +154,7 @@ def test_register_ufunc():
         if method != "__call__":
             ufunc = getattr(ufunc, method)
 
-        fun = Function(lambda x: ufunc(x) * 2)
-        return FunctionCall(fun, *inputs, **kwargs)
+        return FunctionCall(lambda x: ufunc(x) * 2, *inputs, **kwargs)
 
     f = Symbolic()
     x = np.sqrt(f)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -17,11 +17,12 @@ class Expr(Expression):
     def _pipda_eval(self, data, context):
         ...
 
+
 def test_expression():
 
     f = Expr()
     # hashable
-    d = {f: 1}
+    d = {f: 1}  # noqa
     assert isinstance(f.a, ReferenceAttr)
     assert isinstance(f[1], ReferenceItem)
     assert isinstance(f + 1, OperatorCall)
@@ -48,8 +49,8 @@ def test_expression():
     assert isinstance(1 | f, OperatorCall)
     assert isinstance(f ^ 1, OperatorCall)
     assert isinstance(1 ^ f, OperatorCall)
-    assert isinstance(f ** 1, OperatorCall)
-    assert isinstance(1 ** f, OperatorCall)
+    assert isinstance(f**1, OperatorCall)
+    assert isinstance(1**f, OperatorCall)
     assert isinstance(f > 1, OperatorCall)
     assert isinstance(1 > f, OperatorCall)
     assert isinstance(f < 1, OperatorCall)
@@ -82,8 +83,8 @@ def test_op_to_verb():
         return str(data)
 
     a = f.x >> stringify()
-    # assert a == 'x'
-    assert str(f.x) == 'x'
+    assert a == 'x' and isinstance(a, str)
+    assert str(f.x) == "x"
 
 
 def test_test_pipda_attr():
@@ -153,9 +154,8 @@ def test_register_ufunc():
         if method != "__call__":
             ufunc = getattr(ufunc, method)
 
-        fun = Function(lambda x: ufunc(x) * 2, None, {})
+        fun = Function(lambda x: ufunc(x) * 2)
         return FunctionCall(fun, *inputs, **kwargs)
-
 
     f = Symbolic()
     x = np.sqrt(f)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -83,7 +83,7 @@ def test_op_to_verb():
         return str(data)
 
     a = f.x >> stringify()
-    assert a == 'x' and isinstance(a, str)
+    assert a == "x" and isinstance(a, str)
     assert str(f.x) == "x"
 
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,6 +1,7 @@
 import pytest  # noqa
 import warnings
 
+# from pipda.verb import register_verb
 from pipda.function import (
     register_func,
     FunctionCall,

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -21,6 +21,9 @@ def test_function():
     def arithm(op, x, y):
         return op(x, y)
 
+    with pytest.raises(ValueError):
+        arithm.register(int)
+
     call = arithm(f["add"], 4, 1)
     assert str(call) == "arithm(add, 4, 1)"
     assert call._pipda_eval(data, Context.EVAL) == 5

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -268,3 +268,18 @@ def test_plain():
         warnings.simplefilter("error")
         out = add2(1, 2)
         assert out == 2
+
+
+def test_overwrite_doc():
+
+    @register_func(plain=True)
+    def func():
+        """doc1"""
+        return 1
+
+    @func.register(overwrite_doc=True)
+    def _func():
+        """doc2"""
+        return 2
+
+    assert func.__doc__ == "doc2"

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -305,3 +305,80 @@ def test_pipeable_context():
 
     out = "abc" >> func(f.x)
     assert out == "abcx" and isinstance(out, str)
+
+
+def test_dispatch_args_args():
+
+    @register_func(cls=int, dispatchable=True, dispatch_args="args")
+    def func(x, y):
+        return 1
+
+    @func.register(str)
+    def _func(x, y):
+        return 2
+
+    out = func("a", 2)
+    assert out == 2 and isinstance(out, int)
+
+    out = func(2, "a")
+    assert out == 1 and isinstance(out, int)
+
+    with pytest.raises(NotImplementedError):
+        func(x="a", y=2)
+
+
+def test_dispatch_args_kwargs():
+
+    @register_func(cls=int, dispatchable=True, dispatch_args="kwargs")
+    def func(x, y):
+        return 1
+
+    @func.register(str)
+    def _func(x, y):
+        return 2
+
+    out = func("a", y=2)
+    assert out == 1 and isinstance(out, int)
+
+    out = func(2, y="a")
+    assert out == 2 and isinstance(out, int)
+
+    with pytest.raises(NotImplementedError):
+        func("a", 2)
+
+
+def test_dispatch_args_all():
+
+    @register_func(cls=int, dispatchable=True, dispatch_args="all")
+    def func(x, y):
+        return 1
+
+    @func.register(str)
+    def _func(x, y):
+        return 2
+
+    out = func("a", y=2)
+    assert out == 2 and isinstance(out, int)
+
+    out = func(2, y="a")
+    assert out == 1 and isinstance(out, int)
+
+    out = func("a", 2)
+    assert out == 2 and isinstance(out, int)
+
+
+def test_dispatch_args_first():
+
+    @register_func(cls=int, dispatchable=True, dispatch_args="first")
+    def func(x, y):
+        return 1
+
+    @func.register(str)
+    def _func(x, y):
+        return 2
+
+    out = func("a", 1)
+    assert out == 2 and isinstance(out, int)
+
+    out = func(2, "a")
+    assert out == 1 and isinstance(out, int)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -15,10 +15,7 @@ from pipda.piping import register_piping
 def test_function():
     f = Symbolic()
 
-    data = {
-        "add": lambda x, y: x + y,
-        "sub": lambda x, y: x - y
-    }
+    data = {"add": lambda x, y: x + y, "sub": lambda x, y: x - y}
 
     @register_func
     def arithm(op, x, y):
@@ -73,7 +70,6 @@ def test_no_expr_args():
 
 # no extra_context supported for function
 def test_extra_contexts():
-
     @register_func()
     def add(x, plus):
         return f"{x} + {plus}"
@@ -109,7 +105,7 @@ def test_meta():
 def test_dispatchable():
     f = Symbolic()
 
-    @register_func(dispatchable={'x', 'y'})
+    @register_func(dispatchable={"x", "y"})
     def add(x, y):
         return x + y
 
@@ -134,7 +130,6 @@ def test_dispatchable():
 
 
 def test_pipeable():
-
     @register_func(pipeable=True)
     def add(x, y):
         return x + y
@@ -150,8 +145,7 @@ def test_pipeable():
 
 
 def test_dispatchable_and_pipeable():
-
-    @register_func(dispatchable={'x', 'y'}, pipeable=True)
+    @register_func(dispatchable={"x", "y"}, pipeable=True)
     def add(x, y):
         return x + y
 
@@ -173,11 +167,10 @@ def test_dispatchable_and_pipeable():
 
 
 def test_register_func_funclass():
-
     class MyFunction(PipeableFunction):
         ...
 
-    @register_func(pipeable={'x', 'y'}, funclass=MyFunction)
+    @register_func(pipeable={"x", "y"}, funclass=MyFunction)
     def add(x, y):
         return x + y
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -307,9 +307,9 @@ def test_pipeable_context():
     assert out == "abcx" and isinstance(out, str)
 
 
-def test_dispatch_args_args():
+def test_dispatchable_args():
 
-    @register_func(cls=int, dispatchable=True, dispatch_args="args")
+    @register_func(cls=int, dispatchable="args")
     def func(x, y):
         return 1
 
@@ -327,9 +327,9 @@ def test_dispatch_args_args():
         func(x="a", y=2)
 
 
-def test_dispatch_args_kwargs():
+def test_dispatchable_kwargs():
 
-    @register_func(cls=int, dispatchable=True, dispatch_args="kwargs")
+    @register_func(cls=int, dispatchable="kwargs")
     def func(x, y):
         return 1
 
@@ -347,9 +347,9 @@ def test_dispatch_args_kwargs():
         func("a", 2)
 
 
-def test_dispatch_args_all():
+def test_dispatchable_all():
 
-    @register_func(cls=int, dispatchable=True, dispatch_args="all")
+    @register_func(cls=int, dispatchable="all")
     def func(x, y):
         return 1
 
@@ -367,9 +367,9 @@ def test_dispatch_args_all():
     assert out == 2 and isinstance(out, int)
 
 
-def test_dispatch_args_first():
+def test_dispatchable_first():
 
-    @register_func(cls=int, dispatchable=True, dispatch_args="first")
+    @register_func(cls=int, dispatchable="first")
     def func(x, y):
         return 1
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -108,7 +108,7 @@ def test_meta():
 def test_dispatchable():
     f = Symbolic()
 
-    @register_func(dispatchable={"x", "y"})
+    @register_func(dispatchable=True)
     def add(x, y):
         return x + y
 
@@ -148,7 +148,7 @@ def test_pipeable():
 
 
 def test_dispatchable_and_pipeable():
-    @register_func(dispatchable={"x", "y"}, pipeable=True)
+    @register_func(dispatchable=True, pipeable=True)
     def add(x, y):
         return x + y
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -109,8 +109,7 @@ def test_dispatchable():
     def mul(x, y):
         return x * y
 
-    @mul.register(str, backend="back")
-    @mul.register(int, backend="back")
+    @mul.register((str, int), backend="back")
     def _(x, y):
         return f"{x} * {y}"
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -3,6 +3,7 @@ import warnings
 
 from pipda.function import (
     register_func,
+    register_plain,
     FunctionCall,
     PipeableFunctionCall,
 )
@@ -224,3 +225,27 @@ def test_backends():
 
     with pytest.raises(NotImplementedError):
         add(1.0, 2.0, __backend="back")
+
+
+def test_plain():
+    @register_plain
+    def add0(x, y):
+        return x + y
+
+    out = add0(1, 2)
+    assert out == 3
+
+    @register_plain(is_holder=False)
+    def add(x, y):
+        return x + y
+
+    @add.register("back")
+    def _(x, y):
+        return x * y
+
+    with pytest.warns(MultiImplementationsWarning):
+        out = add(1, 2)
+        assert out == 2
+
+    with pytest.raises(NotImplementedError):
+        add(1, 2, __backend="back2")

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -48,4 +48,4 @@ def test_register_operator():
 
     expr = ~f["x"]
     assert str(expr) == "~x"
-    assert expr._pipda_eval({"x": 2}, Context.EVAL) == -3 # ~2
+    assert expr._pipda_eval({"x": 2}, Context.EVAL) == -3  # ~2

--- a/tests/test_piping.py
+++ b/tests/test_piping.py
@@ -1,6 +1,6 @@
 import pytest
 from pipda.operator import OperatorCall
-from pipda.verb import register_verb, Verb
+from pipda.verb import register_verb
 from pipda.piping import (
     register_piping,
     patch_classes,
@@ -11,10 +11,7 @@ from pipda.piping import (
 
 def test_register_piping():
 
-    class MyVerb(Verb):
-        ...
-
-    @register_verb(int, verbclass=MyVerb)
+    @register_verb(int)
     def incre(x):
         return x + 1
 

--- a/tests/test_piping.py
+++ b/tests/test_piping.py
@@ -10,7 +10,6 @@ from pipda.piping import (
 
 
 def test_register_piping():
-
     @register_verb(int)
     def incre(x):
         return x + 1
@@ -33,7 +32,6 @@ def test_register_piping():
 
 
 def test_patching():
-
     class Data:
         def __init__(self, x):
             self.x = x
@@ -111,7 +109,6 @@ def test_patching_pandas():
 
 
 def test_imethod():
-
     @register_verb(int)
     def incre(x):
         return x + 1
@@ -129,7 +126,6 @@ def test_imethod():
 
 
 def test_patch_imethod():
-
     class Data:
         def __init__(self, x):
             self.x = x

--- a/tests/test_piping.py
+++ b/tests/test_piping.py
@@ -1,6 +1,6 @@
 import pytest
 from pipda.operator import OperatorCall
-from pipda.verb import register_verb
+from pipda.verb import register_verb, Verb
 from pipda.piping import (
     register_piping,
     patch_classes,
@@ -10,7 +10,11 @@ from pipda.piping import (
 
 
 def test_register_piping():
-    @register_verb(int)
+
+    class MyVerb(Verb):
+        ...
+
+    @register_verb(int, verbclass=MyVerb)
     def incre(x):
         return x + 1
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -17,12 +17,12 @@ def test_cant_eval_without_context():
 
 def test_str():
     f = Symbolic()
-    assert str(f.a) == 'a'
-    assert str(f.a.b) == 'a.b'
-    assert str(f.a['b']) == "a[b]"
-    assert str(f['a'].b) == "a.b"
+    assert str(f.a) == "a"
+    assert str(f.a.b) == "a.b"
+    assert str(f.a["b"]) == "a[b]"
+    assert str(f["a"].b) == "a.b"
     assert str(f[1:3]) == "[1:3]"
-    assert str(f[1:f.b]) == "[1:b]"
+    assert str(f[1 : f.b]) == "[1:b]"
 
 
 def test_attr_eval():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,7 +113,7 @@ def test_has_expr():
 
 def test_evaluate_expr():
     class FakeExpr:
-        def _pipda_eval(self, data, context):
+        def _pipda_eval(self, data, context, backend):
             return str(data)
 
     assert evaluate_expr(2, 1, Context.EVAL) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,7 +113,7 @@ def test_has_expr():
 
 def test_evaluate_expr():
     class FakeExpr:
-        def _pipda_eval(self, data, context, backend):
+        def _pipda_eval(self, data, context):
             return str(data)
 
     assert evaluate_expr(2, 1, Context.EVAL) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ from pipda.utils import *
 
 
 def test_is_piping_verbcall_normal():
-
     @register_verb(int)
     def iden(x):
         return x
@@ -30,8 +29,8 @@ def test_is_piping_verbcall_normal():
     # no warning
     assert iden2(1) == 1 and isinstance(iden2(1), int)
 
-def test_is_piping_verbcall_piping():
 
+def test_is_piping_verbcall_piping():
     @register_verb(int, ast_fallback="piping")
     def iden(x):
         return x
@@ -45,7 +44,6 @@ def test_is_piping_verbcall_piping():
 
 
 def test_is_piping_verbcall_normal_warning():
-
     @register_verb(int, ast_fallback="normal_warning")
     def iden(x):
         return x
@@ -66,7 +64,6 @@ def test_is_piping_verbcall_normal_warning():
 
 
 def test_is_piping_verbcall_piping_warning():
-
     @register_verb(int, ast_fallback="piping_warning")
     def iden(x):
         return x
@@ -82,7 +79,6 @@ def test_is_piping_verbcall_piping_warning():
 
 
 def test_is_piping_verbcall_raise():
-
     @register_verb(int, ast_fallback="raise")
     def iden(x):
         return x
@@ -101,7 +97,6 @@ def test_is_piping_verbcall_raise():
 
 
 def test_is_piping_verbcall_raise():
-
     @register_verb(int, ast_fallback="raise")
     def iden(x):
         return x
@@ -149,10 +144,11 @@ def test_has_expr():
 
     assert has_expr(f)
     assert not has_expr(1)
-    assert has_expr(f+1)
+    assert has_expr(f + 1)
     assert has_expr([f])
-    assert has_expr(slice(f, f+1))
-    assert has_expr({'a': f})
+    assert has_expr(slice(f, f + 1))
+    assert has_expr({"a": f})
+
 
 def test_evaluate_expr():
     class FakeExpr:
@@ -160,11 +156,9 @@ def test_evaluate_expr():
             return str(data)
 
     assert evaluate_expr(2, 1, Context.EVAL) == 2
-    assert evaluate_expr(FakeExpr(), 1, Context.EVAL) == '1'
-    assert evaluate_expr([FakeExpr()], 1, Context.EVAL) == ['1']
+    assert evaluate_expr(FakeExpr(), 1, Context.EVAL) == "1"
+    assert evaluate_expr([FakeExpr()], 1, Context.EVAL) == ["1"]
     assert evaluate_expr(
-        slice(FakeExpr(), FakeExpr()),
-        1,
-        Context.EVAL
-    ) == slice('1', '1')
-    assert evaluate_expr({'a': FakeExpr()}, 1, Context.EVAL) == {'a': '1'}
+        slice(FakeExpr(), FakeExpr()), 1, Context.EVAL
+    ) == slice("1", "1")
+    assert evaluate_expr({"a": FakeExpr()}, 1, Context.EVAL) == {"a": "1"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,11 @@
 import pytest
 
 from pipda import register_verb, VerbCall, Symbolic, evaluate_expr, Context
-from pipda.utils import PipeableCallCheckWarning, PipeableCallCheckError, has_expr
+from pipda.utils import (
+    PipeableCallCheckWarning,
+    PipeableCallCheckError,
+    has_expr,
+)
 
 
 def test_is_piping_verbcall_normal():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
-from pipda import *
-from pipda.utils import *
+from pipda import register_verb, VerbCall, Symbolic, evaluate_expr, Context
+from pipda.utils import VerbCallingCheckWarning, VerbCallingCheckError, has_expr
 
 
 def test_is_piping_verbcall_normal():
@@ -12,11 +12,11 @@ def test_is_piping_verbcall_normal():
     # AST node in pytest's asserts can't be detected
     # fallbacks to normal call
     with pytest.warns(VerbCallingCheckWarning):
-        assert iden(1) == 1 and isinstance(iden(1), int)
+        assert (1 >> iden()) == 1 and isinstance(1 >> iden(), int)
 
     # So it doesn't work with piping call
-    with pytest.raises(TypeError), pytest.warns(VerbCallingCheckWarning):
-        assert (1 >> iden()) == 1
+    with pytest.warns(VerbCallingCheckWarning):
+        assert isinstance(iden(1), VerbCall)
 
     # AST node can be detected here
     a = 1 >> iden()
@@ -94,49 +94,6 @@ def test_is_piping_verbcall_raise():
 
     a = 1 >> iden()
     assert a == 1 and isinstance(a, int)
-
-
-def test_is_piping_verbcall_raise():
-    @register_verb(int, ast_fallback="raise")
-    def iden(x):
-        return x
-
-    with pytest.raises(VerbCallingCheckError):
-        assert iden(1)
-
-    with pytest.raises(VerbCallingCheckError):
-        assert 1 >> iden()
-
-    a = iden(1)
-    assert a == 1 and isinstance(a, int)
-
-    a = 1 >> iden()
-    assert a == 1 and isinstance(a, int)
-
-
-# def test_is_piping_verbcall_fallback_arg():
-
-#     @register_verb(int, ast_fallback="raise")
-#     def iden(x):
-#         return x
-
-#     assert iden(1, __ast_fallback="normal") == 1
-#     assert isinstance(iden(1, __ast_fallback="normal"), int)
-
-#     assert 1 >> iden(__ast_fallback="piping") == 1
-#     assert isinstance(1 >> iden(__ast_fallback="piping"), int)
-
-#     with pytest.warns(VerbCallingCheckWarning):
-#         assert (
-#             iden(1, __ast_fallback="normal_warning") == 1
-#             and isinstance(iden(1, __ast_fallback="normal_warning"), int)
-#         )
-
-#     with pytest.warns(VerbCallingCheckWarning), pytest.raises(TypeError):
-#         assert (1 >> iden(__ast_fallback="normal_warning")) == 1
-
-#     with pytest.raises(VerbCallingCheckError):
-#         assert iden()  # fallback to raise
 
 
 def test_has_expr():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pipda import register_verb, VerbCall, Symbolic, evaluate_expr, Context
-from pipda.utils import VerbCallingCheckWarning, VerbCallingCheckError, has_expr
+from pipda.utils import PipeableCallCheckWarning, PipeableCallCheckError, has_expr
 
 
 def test_is_piping_verbcall_normal():
@@ -11,11 +11,11 @@ def test_is_piping_verbcall_normal():
 
     # AST node in pytest's asserts can't be detected
     # fallbacks to normal call
-    with pytest.warns(VerbCallingCheckWarning):
+    with pytest.warns(PipeableCallCheckWarning):
         assert (1 >> iden()) == 1 and isinstance(1 >> iden(), int)
 
     # So it doesn't work with piping call
-    with pytest.warns(VerbCallingCheckWarning):
+    with pytest.warns(PipeableCallCheckWarning):
         assert isinstance(iden(1), VerbCall)
 
     # AST node can be detected here
@@ -50,11 +50,11 @@ def test_is_piping_verbcall_normal_warning():
 
     # AST node in pytest's asserts can't be detected
     # fallbacks to normal call
-    with pytest.warns(VerbCallingCheckWarning):
+    with pytest.warns(PipeableCallCheckWarning):
         assert iden(1) == 1 and isinstance(iden(1), int)
 
     # So it doesn't work with piping call
-    with pytest.warns(VerbCallingCheckWarning), pytest.raises(TypeError):
+    with pytest.warns(PipeableCallCheckWarning), pytest.raises(TypeError):
         assert (1 >> iden()) == 1
 
     # AST node can be detected here
@@ -68,10 +68,10 @@ def test_is_piping_verbcall_piping_warning():
     def iden(x):
         return x
 
-    with pytest.warns(VerbCallingCheckWarning):
+    with pytest.warns(PipeableCallCheckWarning):
         assert isinstance(iden(1), VerbCall)
 
-    with pytest.warns(VerbCallingCheckWarning):
+    with pytest.warns(PipeableCallCheckWarning):
         assert (1 >> iden()) == 1 and isinstance(1 >> iden(), int)
 
     a = iden(1)
@@ -83,10 +83,10 @@ def test_is_piping_verbcall_raise():
     def iden(x):
         return x
 
-    with pytest.raises(VerbCallingCheckError):
+    with pytest.raises(PipeableCallCheckError):
         assert iden(1)
 
-    with pytest.raises(VerbCallingCheckError):
+    with pytest.raises(PipeableCallCheckError):
         assert 1 >> iden()
 
     a = iden(1)

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -255,7 +255,7 @@ def test_multiple_backends():
     def add(x, y):
         return x + y
 
-    @add.register(int, backend="back")
+    @add.register((int, set), backend="back")
     def _(x, y):
         return x - y
 
@@ -266,6 +266,7 @@ def test_multiple_backends():
         warnings.simplefilter("error")
         assert add(2, 1, __ast_fallback="normal", __backend="back") == 1
         assert add(2, 1, __ast_fallback="normal", __backend="_default") == 3
+        assert add({1, 2}, {1}, __ast_fallback="normal") == {2}
 
     with pytest.raises(NotImplementedError):
         add(2, 1, __ast_fallback="normal", __backend="not_back")

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -269,3 +269,18 @@ def test_multiple_backends():
 
     with pytest.raises(NotImplementedError):
         add(2, 1, __ast_fallback="normal", __backend="not_back")
+
+
+def test_favored():
+
+    @register_verb(int)
+    def add(x, y):
+        return x + y
+
+    @add.register(int, backend="back", favored=True)
+    def _(x, y):
+        return x - y
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert add(2, 1, __ast_fallback="normal") == 1

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -6,7 +6,6 @@ from pipda.piping import register_piping
 from pipda.symbolic import Symbolic
 from pipda.context import Context
 from pipda.expression import Expression
-from pipda.function import register_func
 from pipda.verb import register_verb, VerbCall
 from pipda.utils import MultiImplementationsWarning
 
@@ -336,41 +335,3 @@ def test_kw_context():
 
     out = {"a": 1, "b": 2, "c": 3} >> update({"b": f["a"]}, rm=f.a)
     assert out == {"b": 1, "c": 3} and isinstance(out, dict)
-
-
-def test_passing_backend_down():
-    f = Symbolic()
-
-    @register_verb(context=Context.EVAL)
-    def add(x, y):
-        raise NotImplementedError
-
-    @add.register(str, backend="back")
-    def _(x, y):
-        return str(x) + str(y)
-
-    @add.register(int, backend="back2")
-    def _(x, y):
-        return x * y
-
-    @register_func()
-    def double(x):
-        raise NotImplementedError
-
-    @double.register(backend="back")
-    def _(x):
-        return x * 2
-
-    @double.register(backend="back2")
-    def _(x):
-        return x * 3
-
-    # backend is passed down
-    out = add("ab", double(f[:1]))
-    assert out == "abaa" and isinstance(out, str)
-
-    out = add(2, double(f * 2))
-    assert out == 24 and isinstance(out, int)
-
-    out = add("a", double(f * 2), __backend="back")
-    assert out == "aaaaa" and isinstance(out, str)

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -5,22 +5,26 @@ import numpy as np
 from pipda.piping import register_piping
 from pipda.symbolic import Symbolic
 from pipda.context import Context
-from pipda.verb import *
+from pipda.expression import Expression
+from pipda.verb import register_verb, VerbCall
 
 
 def test_str():
     f = Symbolic()
+
     class F:
         dep = False
+
         def __str__(self) -> str:
             return "verb"
+
     verb = F()
 
     call = VerbCall(verb, f.x)
-    assert str(call) == 'verb(., x)'
+    assert str(call) == "verb(., x)"
 
     call = VerbCall(verb, x=f.x)
-    assert str(call) == 'verb(., x=x)'
+    assert str(call) == "verb(., x=x)"
 
 
 def test_pending_context():
@@ -39,7 +43,7 @@ def test_extra_contexts():
     @register_verb(
         dict,
         context=Context.EVAL,
-        extra_contexts={'col': Context.SELECT},
+        extra_contexts={"col": Context.SELECT},
     )
     def subset(data, subdata, col):
         return subdata[col]
@@ -85,7 +89,7 @@ def test_register_more_types_inherit_context():
     @register_verb(
         list,
         context=Context.SELECT,
-        extra_contexts={'plus': Context.EVAL},
+        extra_contexts={"plus": Context.EVAL},
     )
     def select(data, indices, *, plus):
         return [data[i + plus] for i in indices]
@@ -94,7 +98,8 @@ def test_register_more_types_inherit_context():
     def _1(data, indices, *, plus):
         return tuple(data[i + plus] for i in indices)
 
-    class MyList(list): ...
+    class MyList(list):
+        ...
 
     @select.register(
         MyList,
@@ -117,8 +122,7 @@ def test_register_more_types_inherit_context():
 def test_numpy_ufunc():
 
     fun = register_verb(
-        np.ndarray,
-        func=np.sqrt, signature=inspect.signature(lambda x: None)
+        np.ndarray, func=np.sqrt, signature=inspect.signature(lambda x: None)
     )
     out = fun(np.array([1, 4, 9]))
     assert out == pytest.approx([1, 2, 3])
@@ -204,7 +208,6 @@ def test_error():
 
 
 def test_registered():
-
     @register_verb(int)
     def incre(x):
         return x + 1
@@ -232,7 +235,6 @@ def test_register_non_callable():
 
 
 def test_types_none():
-
     @register_verb(None)
     def sum_(x):
         """Doc for sum"""
@@ -276,7 +278,6 @@ def test_meta():
 
 
 def test_nparray_as_data():
-
     @register_verb(np.ndarray)
     def sum_(data):
         return data.sum()

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -6,6 +6,7 @@ from pipda.piping import register_piping
 from pipda.symbolic import Symbolic
 from pipda.context import Context
 from pipda.expression import Expression
+from pipda.function import register_func
 from pipda.verb import register_verb, VerbCall
 from pipda.utils import MultiImplementationsWarning
 
@@ -335,3 +336,41 @@ def test_kw_context():
 
     out = {"a": 1, "b": 2, "c": 3} >> update({"b": f["a"]}, rm=f.a)
     assert out == {"b": 1, "c": 3} and isinstance(out, dict)
+
+
+def test_passing_backend_down():
+    f = Symbolic()
+
+    @register_verb(context=Context.EVAL)
+    def add(x, y):
+        raise NotImplementedError
+
+    @add.register(str, backend="back")
+    def _(x, y):
+        return str(x) + str(y)
+
+    @add.register(int, backend="back2")
+    def _(x, y):
+        return x * y
+
+    @register_func()
+    def double(x):
+        raise NotImplementedError
+
+    @double.register(backend="back")
+    def _(x):
+        return x * 2
+
+    @double.register(backend="back2")
+    def _(x):
+        return x * 3
+
+    # backend is passed down
+    out = add("ab", double(f[:1]))
+    assert out == "abaa" and isinstance(out, str)
+
+    out = add(2, double(f * 2))
+    assert out == 24 and isinstance(out, int)
+
+    out = add("a", double(f * 2), __backend="back")
+    assert out == "aaaaa" and isinstance(out, str)

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -300,3 +300,38 @@ def test_overwrite_doc():
         return 2
 
     assert func.__doc__ == "doc2"
+
+
+def test_expr_as_data():
+
+    f = Symbolic()
+
+    @register_verb(int)
+    def identity(data):
+        return data
+
+    @register_verb(int)
+    def add(x, y):
+        return x + y
+
+    out = 1 >> identity() >> add(f)
+    assert out == 2 and isinstance(out, int)
+
+
+def test_kw_context():
+
+    f = Symbolic()
+
+    @register_verb(
+        dict,
+        context=Context.EVAL,
+        kw_context={'rm': Context.SELECT},
+    )
+    def update(data, subdata, rm):
+        data = data.copy()
+        data.update(subdata)
+        del data[rm]
+        return data
+
+    out = {"a": 1, "b": 2, "c": 3} >> update({"b": f["a"]}, rm=f.a)
+    assert out == {"b": 1, "c": 3} and isinstance(out, dict)

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -285,3 +285,18 @@ def test_favored():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         assert add(2, 1, __ast_fallback="normal") == 1
+
+
+def test_overwrite_doc():
+
+    @register_verb(int)
+    def func(data):
+        """doc1"""
+        return 1
+
+    @func.register(int, backend="back", overwrite_doc=True)
+    def _func(data):
+        """doc2"""
+        return 2
+
+    assert func.__doc__ == "doc2"

--- a/tests/test_verb.py
+++ b/tests/test_verb.py
@@ -152,10 +152,10 @@ def test_as_func():
     out = {"a": 1, "b": 2, "c": 3} >> update(
         plus(
             {"a": 2, "b": f["c"]},
-            f["a"],  # 1 instead 2
+            f["a"],  # 2, instead 1
         )
     )
-    assert out == {"a": 3, "b": 4, "c": 3}
+    assert out == {"a": 4, "b": 5, "c": 3}
 
     out = {"a": 1, "b": 2, "c": 3} >> update(
         plus(


### PR DESCRIPTION
- 💥 Refactor the registered borrowed from `singledispatch`
- ✨ Allow pipeable and dispatchable functions (related: pwwang/datar#148)
- 💥 Change default ast_fallback to "piping_warning" for verbs
- ✨ Allow registering multi-types at a time for dispatchable functions
- ✨ Support backends
- ✨ Allow register plain functions
- ✅ Add level test for context
- ✨ Make pipeable function work as a verb