### PR TITLE
0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python # Set Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -56,9 +56,9 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python # Set Python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test with pytest
         run: poetry run pytest tests/ --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.11.0
+
+- 💥 Simplify `register_expr_array_func` and rename it to `register_array_ufunc`
+
 ## 0.10.0
 
 - 💥 Refactor the registered borrowed from `singledispatch`

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -39,15 +39,12 @@ x._pipda_eval(4)  # 2.0
 
 ```python
 import numpy as np
-from pipda import Symbolic, register_expr_array_ufunc
+from pipda import Symbolic, register_array_ufunc
 
 
- @register_expr_array_func
- def my_ufunc(expr, ufunc, method, *inputs, **kwargs):
-     if method != "__call__":
-         ufunc = getattr(ufunc, method)
-     fun = Function(lambda x: ufunc(x) * 2, None, {})
-     return FunctionCall(fun, *inputs, **kwargs)
+ @register_array_ufunc
+ def my_ufunc(ufunc, x, *args, **kwargs):
+    return ufunc(x, *args, **kwargs) * 2
 
 f = Symbolic()
 x = np.sqrt(f)

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -1,5 +1,5 @@
 from .context import Context, ContextBase
-from .expression import Expression, register_expr_array_func
+from .expression import Expression, register_array_ufunc
 from .function import FunctionCall, register_func
 from .operator import Operator, OperatorCall, register_operator
 from .reference import ReferenceAttr, ReferenceItem

--- a/pipda/__init__.py
+++ b/pipda/__init__.py
@@ -8,7 +8,7 @@ from .utils import evaluate_expr
 from .verb import VerbCall, register_verb
 from .piping import register_piping, _patch_default_classes
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 register_piping(">>")
 _patch_default_classes()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pipda"
-version = "0.10.0"
+version = "0.11.0"
 readme = "README.md"
 description = "A framework for data piping in python"
 authors = ["pwwang <pwwang@pwwang.com>"]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -2,7 +2,7 @@ import pytest
 
 import numpy as np
 from pipda.context import Context
-from pipda.expression import Expression, register_expr_array_func
+from pipda.expression import Expression, register_array_ufunc
 from pipda.function import FunctionCall
 from pipda.reference import ReferenceAttr, ReferenceItem
 from pipda.symbolic import Symbolic
@@ -147,14 +147,11 @@ def test_ufunc():
 
 
 def test_register_ufunc():
-    old_ufunc = Expression._pipda_array_func
+    old_ufunc = Expression._pipda_array_ufunc
 
-    @register_expr_array_func
-    def my_ufunc(expr, ufunc, method, *inputs, **kwargs):
-        if method != "__call__":
-            ufunc = getattr(ufunc, method)
-
-        return FunctionCall(lambda x: ufunc(x) * 2, *inputs, **kwargs)
+    @register_array_ufunc
+    def my_ufunc(ufunc, x, *args, **kwargs):
+        return ufunc(x, *args, **kwargs) * 2
 
     f = Symbolic()
     x = np.sqrt(f)
@@ -163,4 +160,4 @@ def test_register_ufunc():
     out = x._pipda_eval(4, Context.EVAL)
     assert out == 4
 
-    register_expr_array_func(old_ufunc)
+    register_array_ufunc(old_ufunc)


### PR DESCRIPTION
- 💥 Simplify `register_expr_array_func` and rename it to `register_array_ufunc`
